### PR TITLE
Added SMC Presentation visualization

### DIFF
--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,3 +1,4 @@
+using Catlab.Present
 using Catlab.Graphics.Graphviz
 import Catlab.Graphics.Graphviz: Graph, Edge
 import Base.Iterators: flatten
@@ -35,4 +36,31 @@ end
 
 function Graph(op::Union{OpenPetriNet, OpenLabelledPetriNetUntyped, OpenReactionNet, OpenLabelledReactionNetUntyped})
     Graph(apex(op))
+end
+
+function Graph(p::Presentation)
+  ob_names = Symbol.(generators(p, :Ob))
+  hom_names = Symbol.(generators(p, :Hom))
+  hom_dict = Dict{Symbol, Tuple}()
+
+  for hom in generators(p, :Hom)
+    # Evaluate Dom
+    dom_v = if eltype(dom(hom).args) <: GATExpr
+      Tuple(Symbol.(dom(hom).args))
+    else
+      Symbol(dom(hom))
+    end
+
+    # Operate on Codom
+    codom_v = if eltype(codom(hom).args) <: GATExpr
+      Tuple(Symbol.(codom(hom).args))
+    else
+      Symbol(codom(hom))
+    end
+
+    hom_dict[Symbol(hom)] = (dom_v, codom_v)
+  end
+
+  schema_ap = LabelledPetriNet(ob_names, hom_dict...)
+  return Graph(schema_ap)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using LabelledArrays
 using AlgebraicPetri
 using AlgebraicPetri.Epidemiology
 using Catlab.Theories
+using Catlab.Present
 using Catlab.CategoricalAlgebra
 using Catlab.CategoricalAlgebra.FinSets
 
@@ -14,6 +15,10 @@ end
 
 @testset "Types" begin
     include("types.jl")
+end
+
+@testset "Visualization" begin
+    include("visualization.jl")
 end
 
 @testset "Petri" begin

--- a/test/types.jl
+++ b/test/types.jl
@@ -13,13 +13,6 @@ sir_tpetri= PetriNet(TransitionMatrices(sir_petri))
 @test Petri.Model(sir_petri) == Petri.Model(sir_rxn)
 @test Petri.Model(sir_lpetri) == Petri.Model(sir_lrxn)
 
-@test typeof(Graph(sir_petri)) == Graph
-@test typeof(Graph(sir_lpetri)) == Graph
-@test typeof(Graph(sir_rxn)) == Graph
-@test typeof(Graph(open_sir_rxn)) == Graph
-@test typeof(Graph(sir_lrxn)) == Graph
-@test typeof(Graph(open_sir_lrxn)) == Graph
-
 @test inputs(sir_petri, 1) == [1,2]
 @test outputs(sir_petri, 1) == [2,2]
 @test concentration(sir_rxn, 1) == 990

--- a/test/visualization.jl
+++ b/test/visualization.jl
@@ -1,0 +1,49 @@
+@testset "PetriNet Visualization" begin
+  sir_petri = PetriNet(3, ((1, 2), (2, 2)), (2, 3))
+  sir_lpetri = LabelledPetriNet([:S, :I, :R], :inf=>((:S, :I), (:I, :I)), :rec=>(:I, :R))
+  β(u,t) = 1 / sum(u)
+  γ = .25
+  sir_rxn = ReactionNet{Function, Int}([990, 10, 0], (β)=>((1, 2)=>(2,2)), (t->γ)=>(2=>3))
+  open_sir_rxn = Open([1,2], sir_rxn, [3])
+  sir_lrxn = LabelledReactionNet{Number, Int}((:S=>990, :I=>10, :R=>0), (:inf, .001)=>((:S, :I)=>(:I,:I)), (:rec, .25)=>(:I=>:R))
+  open_sir_lrxn = Open([:S,:I], sir_lrxn, [:R])
+
+  sir_tpetri= PetriNet(TransitionMatrices(sir_petri))
+
+  @test typeof(Graph(sir_petri)) == Graph
+  @test typeof(Graph(sir_lpetri)) == Graph
+  @test typeof(Graph(sir_rxn)) == Graph
+  @test typeof(Graph(open_sir_rxn)) == Graph
+  @test typeof(Graph(sir_lrxn)) == Graph
+  @test typeof(Graph(open_sir_lrxn)) == Graph
+end
+
+@testset "Presentation Visualization" begin
+  @present TheoryPetriNet(FreeSymmetricMonoidalCategory) begin
+    T::Ob
+    S::Ob
+    I::Ob
+    O::Ob
+
+    it::Hom(I,T)
+    is::Hom(I,S)
+    ot::Hom(O,T)
+    os::Hom(O,S)
+  end
+
+  @present TheoryMLSchema(FreeSymmetricMonoidalCategory) begin
+    Files::Ob
+    Images::Ob
+    NeuralNet::Ob
+    Accuracy::Ob
+    Metadata::Ob
+
+    extract::Hom(Files, Images)
+    split::Hom(Images, Images⊗Images)
+    train::Hom(NeuralNet⊗Images, NeuralNet⊗Metadata)
+    evaluate::Hom(NeuralNet⊗Images, Accuracy⊗Metadata)
+  end
+
+  @test typeof(Graph(TheoryPetriNet)) == Graph
+  @test typeof(Graph(TheoryMLSchema)) == Graph
+end


### PR DESCRIPTION
This PR adds the tooling to visualize an SMC Presentation as a PetriNet.

This code is being upstreamed from AlgebraicRelations to AlgebraicPetri in response to Issue AlgebraicJulia/AlgebraicRelations.jl#10.