### PR TITLE
Conversion Tooling to Catalyst

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         if: matrix.julia_version != '1.0'
       - name: "Run tests (Julia v1.0)"
         run: |
-          julia -e 'using Pkg; Pkg.activate("test"); Pkg.develop(PackageSpec(path="."))'
+          julia -e 'using Pkg; Pkg.activate("test/v1.0"); Pkg.develop(PackageSpec(path="."))'
           julia --color=yes --check-bounds=yes --project=test test/runtests.jl
         # XXX: Julia 1.0 does not use the Project.toml in `tests` directory.
         if: matrix.julia_version == '1.0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,6 @@ jobs:
       - name: "Run tests (Julia v1.0)"
         run: |
           julia -e 'using Pkg; Pkg.activate("test/v1.0"); Pkg.develop(PackageSpec(path="."))'
-          julia --color=yes --check-bounds=yes --project=test test/runtests.jl
+          julia --color=yes --check-bounds=yes --project=test/v1.0 test/runtests.jl
         # XXX: Julia 1.0 does not use the Project.toml in `tests` directory.
         if: matrix.julia_version == '1.0'

--- a/Project.toml
+++ b/Project.toml
@@ -21,4 +21,5 @@ StatsBase = "^0.33"
 julia = "1.0"
 
 [extras]
+Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 Petri = "4259d249-1051-49fa-8328-3f8ab9391c33"

--- a/Project.toml
+++ b/Project.toml
@@ -21,5 +21,4 @@ StatsBase = "^0.33"
 julia = "1.0"
 
 [extras]
-Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 Petri = "4259d249-1051-49fa-8328-3f8ab9391c33"

--- a/src/AlgebraicPetri.jl
+++ b/src/AlgebraicPetri.jl
@@ -538,9 +538,4 @@ include("interoperability.jl")
 include("visualization.jl")
 include("Epidemiology.jl")
 include("BilayerNetworks.jl")
-
-function __init__()
-  @require Catalyst="479239e8-5488-4da2-87a7-35f2df7eef83" include("CatalystInterop.jl")
-end
-
 end

--- a/src/AlgebraicPetri.jl
+++ b/src/AlgebraicPetri.jl
@@ -539,4 +539,8 @@ include("visualization.jl")
 include("Epidemiology.jl")
 include("BilayerNetworks.jl")
 
+function __init__()
+  @require Catalyst="479239e8-5488-4da2-87a7-35f2df7eef83" include("CatalystInterop.jl")
+end
+
 end

--- a/src/CatalystInterop.jl
+++ b/src/CatalystInterop.jl
@@ -1,0 +1,23 @@
+module CatalystInterop
+  using AlgebraicPetri
+  using Catlab.CategoricalAlgebra
+  using ...Catalyst
+  import ...Catalyst: ReactionSystem
+
+  counter(a) = [count(==(i),a) for i in unique(a)]
+
+  function ReactionSystem(pn::AbstractPetriNet)
+    @parameters t k[1:nt(pn)]
+    @variables S[collect(1:ns(pn))](t)
+
+    rxs = map(1:nt(pn)) do t
+      inpts = pn[incident(pn, t, :it),:is]
+      otpts = pn[incident(pn, t, :ot),:os]
+      in_count = collect(counter(inpts))
+      ot_count = collect(counter(otpts))
+      Reaction(k[t], S[unique(inpts)], S[unique(otpts)], in_count, ot_count)
+    end
+
+    ReactionSystem(rxs, t, S, k)
+  end
+end

--- a/src/CatalystInterop.jl
+++ b/src/CatalystInterop.jl
@@ -1,3 +1,9 @@
+""" Supports conversion from PetriNets to Catalyst ReactionSystems
+
+This provides access to the parameter estimation, optimization, and sensitivity
+tooling provided in the Catalyst library
+"""
+
 module CatalystInterop
   using AlgebraicPetri
   using Catlab.CategoricalAlgebra
@@ -6,6 +12,13 @@ module CatalystInterop
 
   counter(a) = [count(==(i),a) for i in unique(a)]
 
+  """ Convert a general PetriNet to a ReactionSystem
+
+  This conversion forgets any labels or rates provided, and converts all
+  parameters and variables into symbols. It does preserve the ordering of
+  transitions and states though (Transition 1 has a rate of k[1], state 1 has a
+  concentration of S[1])
+  """
   function ReactionSystem(pn::AbstractPetriNet)
     @parameters t k[1:nt(pn)]
     @variables S[collect(1:ns(pn))](t)

--- a/src/interoperability.jl
+++ b/src/interoperability.jl
@@ -25,4 +25,6 @@ function __init__()
       return Petri.Model(collect(values(snames)), Δ)
     end
   end
+
+  @require Catalyst="479239e8-5488-4da2-87a7-35f2df7eef83" include("CatalystInterop.jl")
 end

--- a/test/CatalystInterop.jl
+++ b/test/CatalystInterop.jl
@@ -1,0 +1,10 @@
+module CatalystTest
+  using AlgebraicPetri
+  using Catalyst
+  using Test
+
+  # Test with SIR model
+  sir = PetriNet(3, (1,2)=>(2,2), (2)=>(3))
+  sir_rxn = ReactionSystem(sir)
+  @test sir_rxn isa ReactionSystem
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 AlgebraicPetri = "4f99eebe-17bf-4e98-b6a1-2c4f205a959b"
+Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 AlgebraicPetri = "4f99eebe-17bf-4e98-b6a1-2c4f205a959b"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
+Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"
 Petri = "4259d249-1051-49fa-8328-3f8ab9391c33"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,8 @@ end
     include("bilayernetworks.jl")
 end
 
-@testset "Catalyst Tooling" begin
-  include("CatalystInterop.jl")
+if VERSION >= v"1.3.0"
+  @testset "Catalyst Tooling" begin
+    include("CatalystInterop.jl")
+  end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,9 +34,3 @@ if VERSION >= v"1.3.0"
     include("CatalystInterop.jl")
   end
 end
-
-if VERSION >= v"1.3.0"
-  @testset "Catalyst Tooling" begin
-    include("CatalystInterop.jl")
-  end
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,3 +28,7 @@ end
 @testset "BilayerNetworks" begin
     include("bilayernetworks.jl")
 end
+
+@testset "Catalyst Tooling" begin
+  include("CatalystInterop.jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,8 +29,10 @@ end
   include("bilayernetworks.jl")
 end
 
-@testset "Catalyst Tooling" begin
-  include("CatalystInterop.jl")
+if VERSION >= v"1.3.0"
+  @testset "Catalyst Tooling" begin
+    include("CatalystInterop.jl")
+  end
 end
 
 if VERSION >= v"1.3.0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,11 @@ end
 end
 
 @testset "BilayerNetworks" begin
-    include("bilayernetworks.jl")
+  include("bilayernetworks.jl")
+end
+
+@testset "Catalyst Tooling" begin
+  include("CatalystInterop.jl")
 end
 
 if VERSION >= v"1.3.0"

--- a/test/v1.0/Project.toml
+++ b/test/v1.0/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 AlgebraicPetri = "4f99eebe-17bf-4e98-b6a1-2c4f205a959b"
-Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
 LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"
 Petri = "4259d249-1051-49fa-8328-3f8ab9391c33"


### PR DESCRIPTION
This PR provides tooling for converting from PetriNets to the Catalyst ReactionSystem object.

This allows us to take advantage of the Catalyst parameter estimation tooling once the petrinet is constructed.