### PR TITLE
Added github action to automate rebases on PRs

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,19 @@
+name: Automatic Rebase
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  rebase:
+    name: Rebase
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
Commenting on a PR with "/rebase" will trigger the bot to automatically update the PR with the master branch using a rebase. This will help us not use the "merge master into X" button on GitHub which pollutes the commit log with unnecessary commits that don't add any content.

Signed-off-by: Micah Halter <micah@balena.io>