### PR TITLE
0.7.0 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "AlgebraicPetri"
 uuid = "4f99eebe-17bf-4e98-b6a1-2c4f205a959b"
 license = "MIT"
 authors = ["Micah Halter <micah@mehalter.com>"]
-version = "0.6.5"
+version = "0.7.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/BilayerNetworks.jl
+++ b/src/BilayerNetworks.jl
@@ -88,8 +88,9 @@ end
 
 
 function migrate!(pn::AbstractPetriNet, bn::AbstractBilayerNetwork)
-    balance!(bn)
-    migrate!(pn,bn,
+    bnc = copy(bn)
+    balance!(bnc)
+    migrate!(pn,bnc,
          Dict(:S=>:Qin, :T=>:Box, :I=>:Win, :O=>:Wa),
          Dict(:is=>:arg,
               :it=>:call,
@@ -98,8 +99,9 @@ function migrate!(pn::AbstractPetriNet, bn::AbstractBilayerNetwork)
 end
 
 function migrate!(pn::AbstractLabelledPetriNet, bn::AbstractLabelledBilayerNetwork)
-    balance!(bn)
-    migrate!(pn,bn,
+    bnc = copy(bn)
+    balance!(bnc)
+    migrate!(pn,bnc,
          Dict(:S=>:Qin, :T=>:Box, :I=>:Win, :O=>:Wa, :Name=>:Name),
          Dict(:is=>:arg,
               :it=>:call,


### PR DESCRIPTION
This PR provides a minor bug-fix in the BilayerNetwork conversion function, and increases the AlgebraicPetri version for the 0.7.0 release, which includes the addition of the following features:

- Added Requires.jl to reduce unnecessary dependencies
- Added Docstrings to core functionality
- Added BilayerNetwork tooling and conversion to and from Petri nets
- Added interop tooling with Catalyst.jl