### PR TITLE
Fix hardcoded parameter symbol in bilayer net compilation

### DIFF
--- a/src/BilayerNetworks.jl
+++ b/src/BilayerNetworks.jl
@@ -253,7 +253,7 @@ evaluate(bn::AbstractLabelledBilayerNetwork, state; params...) = evaluate!(zeros
 function paramexps(bn::AbstractLabelledBilayerNetwork, params::Symbol)
     map(parts(bn, :Box)) do i
         p = bn[i, :parameter]
-        :(ϕ[$i] *= params[$(Meta.quot(p))])
+        :(ϕ[$i] *= $params[$(Meta.quot(p))])
     end
 end
 

--- a/test/bilayernetworks.jl
+++ b/test/bilayernetworks.jl
@@ -122,11 +122,12 @@ f!(comp_du, comp_ϕ, u, 0)
 
 @test all(abs.(comp_du .- du[[:S,:I,:R]]) .< 1e-9)
 
-eval(AlgebraicPetri.BilayerNetworks.compile(lab_bnsir, :du, :ϕ, :u, :params))
+p, params = params, nothing
+eval(AlgebraicPetri.BilayerNetworks.compile(lab_bnsir, :du, :ϕ, :u, :p))
 comp_du = [0.0,0.0,0.0]
 comp_ϕ = [0.0,0.0,0.0]
 
-f!(comp_du, comp_ϕ, u, params, 0)
+f!(comp_du, comp_ϕ, u, p, 0)
 
 @test all(abs.(comp_du .- du[[:S,:I,:R]]) .< 1e-9)
 


### PR DESCRIPTION
You can see the bug even in the docs (picture below). The unit tests were passing due to an unfortunate coincidence in the local namespace.

<img width="710" alt="image" src="https://user-images.githubusercontent.com/316610/125147658-9232d380-e0e1-11eb-825b-05d5b1b733d5.png">
