### PR TITLE
Simplify state and transition labels in Graphviz display

### DIFF
--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -6,14 +6,15 @@ using StatsBase
 export Graph
 
 function edgify(δ, transition, reverse::Bool)
-  return [Edge(map(string, reverse ? [transition, k] : [k, transition]),
+  return [Edge(reverse ? ["\"$transition\"", "\"$k\""] :
+                         ["\"$k\"", "\"$transition\""],
                Attributes(:label=>"$(δ[k])", :labelfontsize=>"6"))
            for k in collect(keys(δ)) if δ[k] != 0]
 end
 
 function Graph(p::AbstractPetriNet)
-  statenodes = [Node(string(sname(p, s)), Attributes(:shape=>"circle", :color=>"#6C9AC3")) for s in 1:ns(p)]
-  transnodes = [Node(string(tname(p, k)), Attributes(:shape=>"square", :color=>"#E28F41")) for k in 1:nt(p)]
+  statenodes = [Node("\"$(sname(p, s))\"", Attributes(:shape=>"circle", :color=>"#6C9AC3")) for s in 1:ns(p)]
+  transnodes = [Node("\"$(tname(p, k))\"", Attributes(:shape=>"square", :color=>"#E28F41")) for k in 1:nt(p)]
 
   graph_attrs = Attributes(:rankdir=>"LR")
   node_attrs  = Attributes(:shape=>"plain", :style=>"filled", :color=>"white")

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -6,15 +6,14 @@ using StatsBase
 export Graph
 
 function edgify(δ, transition, reverse::Bool)
-  return [Edge(reverse ? ["T_$transition", "S_$k"] :
-                         ["S_$k", "T_$transition"],
+  return [Edge(map(string, reverse ? [transition, k] : [k, transition]),
                Attributes(:label=>"$(δ[k])", :labelfontsize=>"6"))
            for k in collect(keys(δ)) if δ[k] != 0]
 end
 
 function Graph(p::AbstractPetriNet)
-  statenodes = [Node(string("S_$(sname(p, s))"), Attributes(:shape=>"circle", :color=>"#6C9AC3")) for s in 1:ns(p)]
-  transnodes = [Node(string("T_$(tname(p, k))"), Attributes(:shape=>"square", :color=>"#E28F41")) for k in 1:nt(p)]
+  statenodes = [Node(string(sname(p, s)), Attributes(:shape=>"circle", :color=>"#6C9AC3")) for s in 1:ns(p)]
+  transnodes = [Node(string(tname(p, k)), Attributes(:shape=>"square", :color=>"#E28F41")) for k in 1:nt(p)]
 
   graph_attrs = Attributes(:rankdir=>"LR")
   node_attrs  = Attributes(:shape=>"plain", :style=>"filled", :color=>"white")


### PR DESCRIPTION
IMO, given that the state vs transition distinction is captured by both the shape and color of the nodes, it isn't necessary to prepend "S_" and "T_" to the labels.