### PR TITLE
Refactor graphics framework for easier extension

### DIFF
--- a/src/AlgebraicPetri.jl
+++ b/src/AlgebraicPetri.jl
@@ -3,6 +3,7 @@
 module AlgebraicPetri
 
 export TheoryPetriNet, PetriNet, OpenPetriNetOb, AbstractPetriNet, ns, nt, ni, no,
+  os, ot, is, it,
   add_species!, add_transition!, add_transitions!,
   add_input!, add_inputs!, add_output!, add_outputs!, inputs, outputs,
   TransitionMatrices, vectorfield,
@@ -110,6 +111,11 @@ ni(p::AbstractPetriNet) = nparts(p,:I)
 """ Number of output relationships in a Petri net
 """
 no(p::AbstractPetriNet) = nparts(p,:O)
+
+is(p::AbstractPetriNet, args...) = subpart(p, args..., :is)
+os(p::AbstractPetriNet, args...) = subpart(p, args..., :os)
+it(p::AbstractPetriNet, args...) = subpart(p, args..., :it)
+ot(p::AbstractPetriNet, args...) = subpart(p, args..., :ot)
 
 """ Add a species to the Petri net. Label and concentration can be provided
 depending on the kind of Petri net.

--- a/test/modelcomparison.jl
+++ b/test/modelcomparison.jl
@@ -1,7 +1,7 @@
 SIRD = LabelledReactionNet{Float64, Float64}([:S=>0.0, :I=>0.0, :R=>0.0, :D=>0.0],
                                              (:inf=>0.0)=>((:S,:I)=>(:I,:I)),
                                              (:rec=>0.0)=>(:I=>:R),
-												                     (:death=>0.0)=>(:I=>:D))
+                                             (:death=>0.0)=>(:I=>:D))
 
 SIR  = LabelledReactionNet{Float64, Float64}([:S=>1.0, :I=>0.0, :R=>0.0],
                                              (:inf=>0.5)=>((:S,:I)=>(:I,:I)),

--- a/test/petri.jl
+++ b/test/petri.jl
@@ -1,3 +1,6 @@
+using Catlab.Graphs
+using Catlab.Graphics.Graphviz
+
 f = Open([1, 2], PetriNet(4, (1,3), (2,4)), [3, 4])
 
 g = Open([1,2], PetriNet(3, ((1,2),3)), [3])
@@ -38,3 +41,17 @@ lrn′ = Open([:I], LabelledReactionNet{Number,Int}([:I=>10, :R=>0], ((:rec=>.25
 
 death_petri = Open(PetriNet(1, 1=>()));
 @test Graph(death_petri) isa Graph
+
+# Test visualization of nested subgraphs
+SIR  = LabelledReactionNet{Float64, Float64}([:S=>1.0, :I=>0.0, :R=>0.0],
+                                             (:inf=>0.5)=>((:S,:I)=>(:I,:I)),
+                                             (:rec=>0.1)=>(:I=>:R))
+stmts1 = Vector{Statement}([AlgebraicPetri.Subgraph(SIR; pre="1_")])
+graph_attrs = Attributes(:rankdir=>"LR")
+node_attrs  = Attributes(:shape=>"plain", :style=>"filled", :color=>"white")
+edge_attrs  = Attributes(:splines=>"splines")
+g = Graphviz.Digraph("G", stmts1; graph_attrs=graph_attrs, node_attrs=node_attrs, edge_attrs=edge_attrs)
+stmts2 = Vector{Statement}([AlgebraicPetri.Subgraph(g; post="_2")])
+g2 = Graphviz.Digraph("G", stmts2; graph_attrs=graph_attrs, node_attrs=node_attrs, edge_attrs=edge_attrs)
+@test g2 isa Graph
+@test g2.stmts[1].stmts[1].stmts[1].name == "1_s1_2"


### PR DESCRIPTION
This PR adds the ability to define state/transition node generator functions. This prevents a lot of repeated code that handles the wiring between nodes and will hopefully increase consistency between the multiple things we can visualize on a graph (heatmap over transitions/states, restricting positions of certain nodes, subobject highlighting, etc)