### PR TITLE
Constructors of Petri net types are too loose

### DIFF
--- a/examples/covid/coexist/coexist.jl
+++ b/examples/covid/coexist/coexist.jl
@@ -28,7 +28,7 @@ end
 # reactions in an epidemiology Model. Either a state
 # spontaneously changes, or one state causes another to change
 
-ob(x::Symbol,n::Int) = codom(Open([x], LabelledReactionNet{Number,Int}(x=>n), [x])).ob;
+ob(x::Symbol,n::Int) = codom(Open([x], LabelledReactionNet{Number,Int}([x=>n]), [x])).ob;
 function spontaneous_petri(transition::Symbol, rate::Number,
                            s::Symbol, s₀::Int,
                            t::Symbol, t₀::Int)

--- a/examples/enzymes/enzyme_reactions.jl
+++ b/examples/enzymes/enzyme_reactions.jl
@@ -16,7 +16,7 @@ ode(x, t) = ODEProblem(vectorfield(x), concentrations(x), t, rates(x));
 
 # ## Define objects and initial conditions
 
-ob(x) = codom(Open([first(x)], LabelledReactionNet{Number,Int}(x), [first(x)])).ob;
+ob(x) = codom(Open([first(x)], LabelledReactionNet{Number,Int}([x]), [first(x)])).ob;
 K = :K=>33000;
 S = :S=>33000;
 L = :L=>33000;

--- a/src/AlgebraicPetri.jl
+++ b/src/AlgebraicPetri.jl
@@ -21,7 +21,7 @@ using Catlab.Theories
 using LabelledArrays
 using LinearAlgebra: mul!
 
-vectorify(n::Vector) = n
+vectorify(n::AbstractVector) = n
 vectorify(n::Tuple) = length(n) == 1 ? [n] : n
 vectorify(n) = [n]
 
@@ -316,7 +316,7 @@ constructed as follows:
 LabelledPetriNet([:S, :I, :R], :inf=>((:S,:I)=>(:I,:I)), :rec=>(:I=>:R))
 ```
 """
-LabelledPetriNet(n, ts::Vararg{Union{Pair,Tuple}}) = begin
+LabelledPetriNet(n::Union{AbstractVector,Tuple}, ts::Vararg{Union{Pair,Tuple}}) = begin
   p = LabelledPetriNet()
   n = vectorify(n)
   state_idx = state_dict(n)
@@ -371,7 +371,7 @@ constructed as follows:
 ReactionNet{Float64, Float64}([10,1,0], 0.5=>((1,2)=>(2,2)), 0.1=>(2=>3))
 ```
 """
-ReactionNet{R,C}(n, ts::Vararg{Union{Pair,Tuple}}) where {R,C} = begin
+ReactionNet{R,C}(n::Union{AbstractVector,Tuple}, ts::Vararg{Union{Pair,Tuple}}) where {R,C} = begin
   p = ReactionNet{R,C}()
   add_species!(p, length(n), concentration=n)
   for (i, (rate,(ins,outs))) in enumerate(ts)
@@ -432,7 +432,7 @@ constructed as follows:
 ReactionNet{Float64, Float64}([:S=>10,:I=>1,:R=>0], (:inf=>0.5)=>((1,2)=>(2,2)), (:rec=>0.1)=>(2=>3))
 ```
 """
-LabelledReactionNet{R,C}(n, ts::Vararg{Union{Pair,Tuple}}) where {R,C} = begin
+LabelledReactionNet{R,C}(n::Union{AbstractVector,Tuple}, ts::Vararg{Union{Pair,Tuple}}) where {R,C} = begin
   p = LabelledReactionNet{R,C}()
   n = vectorify(n)
   states = map(first, collect(n))


### PR DESCRIPTION
Because they accept essentially any arguments, they create method ambiguities with standard acset constructors.