### PR TITLE
Simplify implementation of `flatten_labels`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-Catlab = "^0.14.13"
+Catlab = "^0.14.14"
 LabelledArrays = "^1"
 Requires = "^1"
 StatsBase = "^0.33"

--- a/src/AlgebraicPetri.jl
+++ b/src/AlgebraicPetri.jl
@@ -461,34 +461,14 @@ tname(p::Union{AbstractLabelledPetriNet,AbstractLabelledReactionNet}, t) = subpa
 flat_symbol(sym::Symbol)::Symbol = sym
 flat_symbol(sym::Tuple)::Symbol = mapreduce(x -> isa(x, Tuple) ? flat_symbol(x) : x, (x, y) -> Symbol(x, "_", y), sym)
 
-# TODO: (Relevant issue: https://github.com/AlgebraicJulia/Catlab.jl/issues/735)
-# After linked issue is resolved, convert following two definitions to a simpler, single line definition:
-# flatten_labels(pn::Union{AbstractLabelledPetriNet, AbstractLabelledReactionNet}) = map(pn, Name=flat_symbol)
-
 """ flatten_labels(pn::AbstractLabelledPetriNet)
 
-Takes a LabelledPetriNet and flattens arbitrarily nested labels on the species and the transitions
-to a single symbol who's previously nested parts are separated by `_`.
+Takes a labeled Petri net or reaction net and flattens arbitrarily nested labels
+on the species and the transitions to a single symbol who's previously nested
+parts are separated by `_`.
 """
-flatten_labels(pn::AbstractLabelledPetriNet) = begin
-  LabelledPetriNet(PetriNet(pn),
-    flat_symbol.(pn[:, :sname]),
-    flat_symbol.(pn[:, :tname]))
-end
-
-""" flatten_labels(pn::LabelledReactionNetUntyped{R,C,S}) where {R,C,S}
-
-Takes a LabelledReactionNet and flattens arbitrarily nested labels on the species and the transitions
-to a single symbol who's previously nested parts are separated by `_`. This maintains the original
-rate and concentration values and types in the newly returned LabelledReactionNet.
-"""
-flatten_labels(pn::LabelledReactionNetUntyped{R,C,S}) where {R,C,S} = begin
-  LabelledReactionNet{R,C}(PetriNet(pn),
-    flat_symbol.(pn[:, :sname]),
-    flat_symbol.(pn[:, :tname]),
-    pn[:, :concentration],
-    pn[:, :rate])
-end
+flatten_labels(pn::Union{AbstractLabelledPetriNet,AbstractLabelledReactionNet}) =
+  map(pn, Name=flat_symbol)
 
 # Interoperability between different types
 


### PR DESCRIPTION
Depends on Catlab v0.14.14, specifically https://github.com/AlgebraicJulia/Catlab.jl/pull/736