### PR TITLE
update for Catalyst v13.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,8 +16,10 @@ Catlab = "^0.14.14"
 LabelledArrays = "^1"
 Requires = "^1"
 StatsBase = "^0.33"
+Catalyst = "^13.0.0"
 julia = "1.6"
 
 [extras]
 Petri = "4259d249-1051-49fa-8328-3f8ab9391c33"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"

--- a/src/CatalystInterop.jl
+++ b/src/CatalystInterop.jl
@@ -22,7 +22,7 @@ module CatalystInterop
   """
   function ReactionSystem(pn::AbstractPetriNet)
     @parameters t k[1:nt(pn)]
-    @variables (S(t))[collect(1:ns(pn))]
+    @species (S(t))[collect(1:ns(pn))]
 
     rxs = map(1:nt(pn)) do t
       inpts = pn[incident(pn, t, :it),:is]


### PR DESCRIPTION
Catalyst 13.0.0 is a breaking change (https://github.com/SciML/Catalyst.jl/blob/master/HISTORY.md), `@variables` is no longer recognized, which is causing the CatalystInterop tests to fail. Do we also want to add Catalyst to the [extras] part of the package, and maybe a [compat] for versions >= 13.0.0?