### PR TITLE
Do not canonicalize `+` and `-` during ODESystem conversion

### DIFF
--- a/src/ModelingToolkitInterop.jl
+++ b/src/ModelingToolkitInterop.jl
@@ -83,15 +83,17 @@ module ModelingToolkitInterop
       end
     end
 
+    plus(x, y) = ModelingToolkit.term(+, x, y; type = Real)
     infs = map(parts(bn, :Qout)) do tv
-      flux = mapreduce(+, incident(bn, tv, :infusion), init=0) do wa
+      flux = mapreduce(plus, incident(bn, tv, :infusion), init=0) do wa
         j = bn[wa, :influx]
         return ϕs[j]
       end
-      flux -= mapreduce(+, incident(bn, tv, :effusion), init=0) do wa
+      flux2 = mapreduce(plus, incident(bn, tv, :effusion), init=0) do wa
         j = bn[wa, :efflux]
         return ϕs[j]
       end
+      flux = ModelingToolkit.term(-, flux, flux2; type = Real)
     end
 
     # We assume bn[:tanvar] ⊆ bn[:variable] here

--- a/test/ModelingToolkitInterop.jl
+++ b/test/ModelingToolkitInterop.jl
@@ -37,9 +37,11 @@ module ModelingToolkitInterop
   eqs = [D(S) ~ -ϕ1, D(I) ~ ϕ1 + ϕ1 - (ϕ1 + ϕ2), D(R) ~ ϕ2]
   eqs2 = [D(S) ~ minus(ϕ1), D(I) ~ minus(plus(ϕ1, ϕ1), plus(ϕ1, ϕ2)), D(R) ~ ϕ2]
   bilayer_example = ODESystem(eqs2, t, name=:BilayerNetwork)
+  simp_bilayer_example = ODESystem(eqs, t, name=:BilayerNetwork)
   petri_example = ODESystem(eqs, t, name=:PetriNet)
 
   @test ODESystem(psir) == petri_example
   @test ODESystem(bnsir) == bilayer_example
+  @test ODESystem(bnsir, simplify = true) == simp_bilayer_example
   @test typeof(ODESystem(PetriNet(psir))) == ODESystem # Sanity check that non-labelled Petri Nets resolve correctly
 end

--- a/test/ModelingToolkitInterop.jl
+++ b/test/ModelingToolkitInterop.jl
@@ -1,6 +1,7 @@
 module ModelingToolkitInterop
   using Test
   using ModelingToolkit
+  using ModelingToolkit: unwrap, term
   using AlgebraicPetri
   using AlgebraicPetri.Epidemiology
   using AlgebraicPetri.BilayerNetworks
@@ -30,8 +31,12 @@ module ModelingToolkitInterop
   D = Differential(t)
   ϕ1 = inf * S * I
   ϕ2 = rec * I
-  eqs = [D(S) ~ +(-ϕ1), D(I) ~ ϕ1 + ϕ1 + -ϕ1 + -ϕ2, D(R) ~ +ϕ2]
-  bilayer_example = ODESystem(eqs, t, name=:BilayerNetwork)
+  plus(x, y) = term(+, unwrap(x), unwrap(y); type = Real)
+  minus(x, y) = term(-, unwrap(x), unwrap(y); type = Real)
+  minus(x) = term(-, unwrap(x); type = Real)
+  eqs = [D(S) ~ -ϕ1, D(I) ~ ϕ1 + ϕ1 - (ϕ1 + ϕ2), D(R) ~ ϕ2]
+  eqs2 = [D(S) ~ minus(ϕ1), D(I) ~ minus(plus(ϕ1, ϕ1), plus(ϕ1, ϕ2)), D(R) ~ ϕ2]
+  bilayer_example = ODESystem(eqs2, t, name=:BilayerNetwork)
   petri_example = ODESystem(eqs, t, name=:PetriNet)
 
   @test ODESystem(psir) == petri_example


### PR DESCRIPTION
PR:
```julia
julia> ModelingToolkit.equations(model_odesys)
2-element Vector{Equation}:
 Differential(t)(A1(t)) ~ (2A1_A1*(A1(t)^2) + A1_A2*A1(t)*A2(t) + A2_A1*A1(t)*A2(t)) - (2A1_A1*(A1(t)^2) + A1_A2*A1(t)*A2(t) + A2_A1*A1(t)*A2(t))
 Differential(t)(A2(t)) ~ (2A2_A2*(A2(t)^2) + A1_A2*A1(t)*A2(t) + A2_A1*A1(t)*A2(t)) - (2A2_A2*(A2(t)^2) + A1_A2*A1(t)*A2(t) + A2_A1*A1(t)*A2(t))
```

Master:
```julia
julia> ModelingToolkit.equations(ODESystem(model_bilayer))
2-element Vector{Equation}:
 Differential(t)(A1(t)) ~ 0
 Differential(t)(A2(t)) ~ 0
```