### PR TITLE
Property Petri Nets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "AlgebraicPetri"
 uuid = "4f99eebe-17bf-4e98-b6a1-2c4f205a959b"
 license = "MIT"
 authors = ["Micah Halter <micah@mehalter.com>"]
-version = "0.8.6"
+version = "0.8.7"
 
 [deps]
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"

--- a/src/AlgebraicPetri.jl
+++ b/src/AlgebraicPetri.jl
@@ -632,6 +632,8 @@ end
 Open(p::PropertyLabelledReactionNet{R,C,T}) where {R,C,T} = OpenPropertyLabelledReactionNet{R,C,T}(p, map(x -> FinFunction([x], ns(p)), 1:ns(p))...)
 
 # Add new parent types
+#
+# TODO: MOVE TO CODE BASED `has_subpart` TO DISPATCH RATHER THAN UNION TYPES
 const AbstractLabelledPetriNet = Union{LabelledPetriNetUntyped,LabelledPetriNet,LabelledReactionNetUntyped,LabelledReactionNet,PropertyLabelledPetriNetUntyped,PropertyLabelledPetriNet,OpenPropertyLabelledReactionNetUntyped,PropertyLabelledReactionNet}
 const AbstractReactionNet = Union{ReactionNet,LabelledReactionNetUntyped,LabelledReactionNet,PropertyReactionNet,OpenPropertyLabelledReactionNetUntyped,PropertyLabelledReactionNet}
 const AbstractLabelledReactionNet = typeintersect(AbstractLabelledPetriNet, AbstractReactionNet)

--- a/src/AlgebraicPetri.jl
+++ b/src/AlgebraicPetri.jl
@@ -657,8 +657,18 @@ function (::Type{T})(pn::AbstractPetriNet, sprops, tprops) where T <: AbstractPr
   pn′
 end
 
-(::Type{T})(pn::AbstractPetriNet, sprops::AbstractDict, tprops::AbstractDict) where T <: AbstractPropertyPetriNet =
-  T(pn, [sprops[sname(pn, s)] for s in 1:ns(pn)], [tprops[tname(pn, t)] for t in 1:nt(pn)])
+function (::Type{T})(pn::AbstractPetriNet, sprops::AbstractDict, tprops::AbstractDict) where T <: AbstractPropertyPetriNet
+  pn′ = T(pn)
+  species = Dict(sname(pn, s)=>s for s in 1:ns(pn))
+  for (name, prop) in sprops
+    set_subpart!(pn′, species[name], :sprop, prop)
+  end
+  transitions = Dict(tname(pn, t)=>t for t in 1:nt(pn))
+  for (name, prop) in tprops
+    set_subpart!(pn′, transitions[name], :tprop, prop)
+  end
+  pn′
+end
 
 """ ACSet definition for a LabelledPetriNet with properties on transitions and states.
 

--- a/src/AlgebraicPetri.jl
+++ b/src/AlgebraicPetri.jl
@@ -13,7 +13,11 @@ export SchPetriNet, PetriNet, OpenPetriNetOb, AbstractPetriNet, ns, nt, ni, no,
   Open, OpenPetriNet, OpenLabelledPetriNet, OpenReactionNet, OpenLabelledReactionNet,
   OpenPetriNetOb, OpenLabelledPetriNetOb, OpenReactionNetOb, OpenLabelledReactionNetOb,
   mca, flatten_labels,
-  SchPropertyPetriNet, AbstractPropertyPetriNet, PropertyPetriNet, sprop, tprop, sprops, tprops
+  AbstractPropertyPetriNet, sprop, tprop, sprops, tprops,
+  SchPropertyPetriNet, SchPropertyLabelledPetriNet, SchPropertyReactionNet, SchPropertyLabelledReactionNet,
+  PropertyPetriNet, PropertyLabelledPetriNet, PropertyReactionNet, PropertyLabelledReactionNet,
+  OpenPropertyPetriNet, OpenPropertyLabelledPetriNet, OpenPropertyReactionNet, OpenPropertyLabelledReactionNet,
+  OpenPropertyPetriNetOb, OpenPropertyLabelledPetriNetOb, OpenPropertyReactionNetOb, OpenPropertyLabelledReactionNetOb
 
 using Catlab
 using Catlab.CategoricalAlgebra
@@ -36,7 +40,7 @@ This type encompasses C-sets where the schema for graphs is a subcategory of C.
 This includes, for example, graphs, symmetric graphs, and reflexive graphs, but
 not half-edge graphs.
 """
-@abstract_acset_type HasPetriNet
+@abstract_acset_type AbstractPetriNet
 
 # Petri Nets
 ############
@@ -57,7 +61,6 @@ See Catlab.jl documentation for description of the @present syntax.
   os::Hom(O, S)
 end
 
-@abstract_acset_type AbstractPetriNet <: HasPetriNet
 @acset_type PetriNet(SchPetriNet, index=[:it, :is, :ot, :os]) <: AbstractPetriNet
 const OpenPetriNetOb, OpenPetriNet = OpenCSetTypes(PetriNet, :S)
 
@@ -69,19 +72,19 @@ the cospan. The OpenPetriNet can be composed over an undirected wiring diagram
 [blog post](https://www.algebraicjulia.org/blog/post/2020/11/structured-cospans-2/)
 for a description of this compositional tooling)
 """
-Open(p::HasPetriNet) = OpenPetriNet(p, map(x -> FinFunction([x], ns(p)), 1:ns(p))...)
+Open(p::AbstractPetriNet) = OpenPetriNet(p, map(x -> FinFunction([x], ns(p)), 1:ns(p))...)
 
 """ Open(p::AbstractPetriNet, legs...)
 
 Generates on OpenPetriNet with legs bundled as described by `legs`
 """
-Open(p::HasPetriNet, legs...) = OpenPetriNet(p, map(l -> FinFunction(l, ns(p)), legs)...)
+Open(p::AbstractPetriNet, legs...) = OpenPetriNet(p, map(l -> FinFunction(l, ns(p)), legs)...)
 
 """ Open(n, p::AbstractPetriNet, m)
 
 Generates on OpenPetriNet with two legs, `n` and `m`
 """
-Open(n, p::HasPetriNet, m) = Open(p, n, m)
+Open(n, p::AbstractPetriNet, m) = Open(p, n, m)
 
 """ PetriNet(n::Int, ts::Vararg{Union{Pair,Tuple}})
 
@@ -107,7 +110,7 @@ PetriNet(n::Int, ts::Vararg{Union{Pair,Tuple}}) = begin
   p
 end
 
-function (::Type{T})(pn::HasPetriNet) where T <: HasPetriNet
+function (::Type{T})(pn::AbstractPetriNet) where T <: AbstractPetriNet
   pn′ = T()
   copy_parts!(pn′, pn)
   pn′
@@ -115,52 +118,52 @@ end
 
 """ Number of states in a Petri net
 """
-ns(p::HasPetriNet) = nparts(p, :S)
+ns(p::AbstractPetriNet) = nparts(p, :S)
 
 """ Number of transitions in a Petri net
 """
-nt(p::HasPetriNet) = nparts(p, :T)
+nt(p::AbstractPetriNet) = nparts(p, :T)
 
 """ Number of input relationships in a Petri net
 """
-ni(p::HasPetriNet) = nparts(p, :I)
+ni(p::AbstractPetriNet) = nparts(p, :I)
 
 """ Number of output relationships in a Petri net
 """
-no(p::HasPetriNet) = nparts(p, :O)
+no(p::AbstractPetriNet) = nparts(p, :O)
 
-is(p::HasPetriNet, args...) = subpart(p, args..., :is)
-os(p::HasPetriNet, args...) = subpart(p, args..., :os)
-it(p::HasPetriNet, args...) = subpart(p, args..., :it)
-ot(p::HasPetriNet, args...) = subpart(p, args..., :ot)
+is(p::AbstractPetriNet, args...) = subpart(p, args..., :is)
+os(p::AbstractPetriNet, args...) = subpart(p, args..., :os)
+it(p::AbstractPetriNet, args...) = subpart(p, args..., :it)
+ot(p::AbstractPetriNet, args...) = subpart(p, args..., :ot)
 
 """ Add a species to the Petri net. Label and concentration can be provided
 depending on the kind of Petri net.
 
 Returns the ID of the species
 """
-add_species!(p::HasPetriNet; kw...) = add_part!(p, :S; kw...)
+add_species!(p::AbstractPetriNet; kw...) = add_part!(p, :S; kw...)
 
 """ Add `n` species to the Petri net. Label and concentration can be provided
 depending on the kind of Petri net.
 
 Returns the ID of the species
 """
-add_species!(p::HasPetriNet, n; kw...) = add_parts!(p, :S, n; kw...)
+add_species!(p::AbstractPetriNet, n; kw...) = add_parts!(p, :S, n; kw...)
 
 """ Add a transition to the Petri net. Label and rate can be provided
 depending on the kind of Petri net.
 
 Returns the ID of the transition
 """
-add_transition!(p::HasPetriNet; kw...) = add_part!(p, :T; kw...)
+add_transition!(p::AbstractPetriNet; kw...) = add_part!(p, :T; kw...)
 
 """ Add `n` transitions to the Petri net. Label and rate can be provided
 depending on the kind of Petri net.
 
 Returns the ID of the transition
 """
-add_transitions!(p::HasPetriNet, n; kw...) = add_parts!(p, :T, n; kw...)
+add_transitions!(p::AbstractPetriNet, n; kw...) = add_parts!(p, :T, n; kw...)
 
 """ add_input!(p::AbstractPetriNet,t,s;kw...)
 
@@ -168,7 +171,7 @@ Add an input relationship to the Petri net between the transition `t` and specie
 
 Returns the ID of the input relationship
 """
-add_input!(p::HasPetriNet, t, s; kw...) = add_part!(p, :I; it=t, is=s, kw...)
+add_input!(p::AbstractPetriNet, t, s; kw...) = add_part!(p, :I; it=t, is=s, kw...)
 
 """ add_inputs!(p::AbstractPetriNet,n,t,s;kw...)
 
@@ -176,7 +179,7 @@ Add input relationships to the Petri net between the transitions `t` and species
 
 Returns the ID of the input relationship
 """
-add_inputs!(p::HasPetriNet, n, t, s; kw...) = add_parts!(p, :I, n; it=t, is=s, kw...)
+add_inputs!(p::AbstractPetriNet, n, t, s; kw...) = add_parts!(p, :I, n; it=t, is=s, kw...)
 
 """ add_output!(p::AbstractPetriNet,t,s;kw...)
 
@@ -184,7 +187,7 @@ Add an output relationship to the Petri net between the transition `t` and speci
 
 Returns the ID of the input relationship
 """
-add_output!(p::HasPetriNet, t, s; kw...) = add_part!(p, :O; ot=t, os=s, kw...)
+add_output!(p::AbstractPetriNet, t, s; kw...) = add_part!(p, :O; ot=t, os=s, kw...)
 
 """ add_outputs!(p::AbstractPetriNet,n,t,s;kw...)
 
@@ -192,41 +195,41 @@ Add output relationships to the Petri net between the transitions `t` and specie
 
 Returns the ID of the input relationship
 """
-add_outputs!(p::HasPetriNet, n, t, s; kw...) = add_parts!(p, :O, n; ot=t, os=s, kw...)
+add_outputs!(p::AbstractPetriNet, n, t, s; kw...) = add_parts!(p, :O, n; ot=t, os=s, kw...)
 
 """ Name of species
 
 Note that this returns an index if labels are not present in the PetriNet
 """
-sname(p::HasPetriNet, s) = (1:ns(p))[s]
+sname(p::AbstractPetriNet, s) = (1:ns(p))[s]
 
 """ Name of transition
 
 Note that this returns an index if labels are not present in the PetriNet
 """
-tname(p::HasPetriNet, t) = (1:nt(p))[t]
+tname(p::AbstractPetriNet, t) = (1:nt(p))[t]
 
 """ Names of species in  a Petri net
 
 Note that this returns indices if labels are not present in the PetriNet
 """
-snames(p::HasPetriNet) = map(s -> sname(p, s), 1:ns(p))
+snames(p::AbstractPetriNet) = map(s -> sname(p, s), 1:ns(p))
 
 """ Names of transitions in  a Petri net
 
 Note that this returns indices if labels are not present in the PetriNet
 """
-tnames(p::HasPetriNet) = map(t -> tname(p, t), 1:nt(p))
+tnames(p::AbstractPetriNet) = map(t -> tname(p, t), 1:nt(p))
 
 # Note: although indexing makes this pretty fast, it is often faster to bulk-convert
 # the PetriNet net into a transition matrix, if you are working with all of the transitions
 """ Input relationships for a transition
 """
-inputs(p::HasPetriNet, t) = subpart(p, incident(p, t, :it), :is)
+inputs(p::AbstractPetriNet, t) = subpart(p, incident(p, t, :it), :is)
 
 """ Output relationships for a transition
 """
-outputs(p::HasPetriNet, t) = subpart(p, incident(p, t, :ot), :os)
+outputs(p::AbstractPetriNet, t) = subpart(p, incident(p, t, :ot), :os)
 
 """ TransitionMatrices
 
@@ -237,7 +240,7 @@ Petri net.
 struct TransitionMatrices
   input::Matrix{Int}
   output::Matrix{Int}
-  TransitionMatrices(p::HasPetriNet) = begin
+  TransitionMatrices(p::AbstractPetriNet) = begin
     input, output = zeros(Int, (nt(p), ns(p))), zeros(Int, (nt(p), ns(p)))
     for i in 1:ni(p)
       input[subpart(p, i, :it), subpart(p, i, :is)] += 1
@@ -283,7 +286,7 @@ being simulated under the law of mass action.
 The resulting function has a signature of the form `f!(du, u, p, t)` and can be
 passed to the DifferentialEquations.jl solver package.
 """
-vectorfield(pn::HasPetriNet) = begin
+vectorfield(pn::AbstractPetriNet) = begin
   tm = TransitionMatrices(pn)
   dt = tm.output - tm.input
   f(du, u, p, t) = begin
@@ -309,7 +312,7 @@ vectorfield of the Petri net being simulated under the law of mass action.
 The resulting function has a signature of the form `f!(du, u, p, t)` and can be
 passed to the DifferentialEquations.jl solver package.
 """
-vectorfield_expr(pn::HasPetriNet) = begin
+vectorfield_expr(pn::AbstractPetriNet) = begin
   fquote = Expr(:function, Expr(:tuple, :du, :u, :p, :t))
   fcode = Expr[]
   p_ix = [tname(pn, i) for i in 1:nt(pn)]
@@ -368,14 +371,13 @@ See Catlab.jl documentation for description of the @present syntax.
   sname::Attr(S, Name)
 end
 
-@abstract_acset_type AbstractLabelledPetriNet <: AbstractPetriNet
-@acset_type LabelledPetriNetUntyped(SchLabelledPetriNet, index=[:it, :is, :ot, :os]) <: AbstractLabelledPetriNet
+@acset_type LabelledPetriNetUntyped(SchLabelledPetriNet, index=[:it, :is, :ot, :os]) <: AbstractPetriNet
 const LabelledPetriNet = LabelledPetriNetUntyped{Symbol}
 const OpenLabelledPetriNetObUntyped, OpenLabelledPetriNetUntyped = OpenACSetTypes(LabelledPetriNetUntyped, :S)
 const OpenLabelledPetriNetOb, OpenLabelledPetriNet = OpenLabelledPetriNetObUntyped{Symbol}, OpenLabelledPetriNetUntyped{Symbol}
 
-Open(p::AbstractLabelledPetriNet) = OpenLabelledPetriNet(p, map(x -> FinFunction([x], ns(p)), 1:ns(p))...)
-Open(p::AbstractLabelledPetriNet, legs...) = begin
+Open(p::LabelledPetriNet) = OpenLabelledPetriNet(p, map(x -> FinFunction([x], ns(p)), 1:ns(p))...)
+Open(p::LabelledPetriNet, legs...) = begin
   s_idx = Dict(sname(p, s) => s for s in 1:ns(p))
   OpenLabelledPetriNet(p, map(l -> FinFunction(map(i -> s_idx[i], l), ns(p)), legs)...)
 end
@@ -424,8 +426,7 @@ See Catlab.jl documentation for description of the @present syntax.
   concentration::Attr(S, Concentration)
 end
 
-@abstract_acset_type AbstractReactionNet <: AbstractPetriNet
-@acset_type ReactionNet(SchReactionNet, index=[:it, :is, :ot, :os]) <: AbstractReactionNet
+@acset_type ReactionNet(SchReactionNet, index=[:it, :is, :ot, :os]) <: AbstractPetriNet
 const OpenReactionNetOb, OpenReactionNet = OpenACSetTypes(ReactionNet, :S)
 
 Open(p::ReactionNet{R,C}, legs...) where {R,C} = OpenReactionNet{R,C}(p, map(l -> FinFunction(l, ns(p)), legs)...)
@@ -471,8 +472,7 @@ See Catlab.jl documentation for description of the @present syntax.
   sname::Attr(S, Name)
 end
 
-@abstract_acset_type AbstractLabelledReactionNet <: AbstractPetriNet
-@acset_type LabelledReactionNetUntyped(SchLabelledReactionNet, index=[:it, :is, :ot, :os]) <: AbstractLabelledReactionNet
+@acset_type LabelledReactionNetUntyped(SchLabelledReactionNet, index=[:it, :is, :ot, :os]) <: AbstractPetriNet
 const LabelledReactionNet{R,C} = LabelledReactionNetUntyped{R,C,Symbol}
 const OpenLabelledReactionNetObUntyped, OpenLabelledReactionNetUntyped = OpenACSetTypes(LabelledReactionNetUntyped, :S)
 const OpenLabelledReactionNetOb{R,C} = OpenLabelledReactionNetObUntyped{R,C,Symbol}
@@ -518,38 +518,23 @@ LabelledReactionNet{R,C}(n::Union{AbstractVector,Tuple}, ts::Vararg{Union{Pair,T
   p
 end
 
-sname(p::Union{AbstractLabelledPetriNet,AbstractLabelledReactionNet}, s) = subpart(p, s, :sname)
-tname(p::Union{AbstractLabelledPetriNet,AbstractLabelledReactionNet}, t) = subpart(p, t, :tname)
-
-flat_symbol(sym::Symbol)::Symbol = sym
-flat_symbol(sym::Tuple)::Symbol = mapreduce(x -> isa(x, Tuple) ? flat_symbol(x) : x, (x, y) -> Symbol(x, "_", y), sym)
-
-""" flatten_labels(pn::AbstractLabelledPetriNet)
-
-Takes a labeled Petri net or reaction net and flattens arbitrarily nested labels
-on the species and the transitions to a single symbol who's previously nested
-parts are separated by `_`.
-"""
-flatten_labels(pn::Union{AbstractLabelledPetriNet,AbstractLabelledReactionNet}) =
-  map(pn, Name=flat_symbol)
-
 # Interoperability between different types
 
-LabelledPetriNet(pn::HasPetriNet, snames, tnames) = begin
+LabelledPetriNet(pn::AbstractPetriNet, snames, tnames) = begin
   pn′ = LabelledPetriNet(pn)
   map(k -> set_subpart!(pn′, k, :sname, snames[k]), keys(snames))
   map(k -> set_subpart!(pn′, k, :tname, tnames[k]), keys(tnames))
   pn′
 end
 
-ReactionNet{R,C}(pn::HasPetriNet, concentrations, rates) where {R,C} = begin
+ReactionNet{R,C}(pn::AbstractPetriNet, concentrations, rates) where {R,C} = begin
   pn′ = ReactionNet{R,C}(pn)
   map(k -> set_subpart!(pn′, k, :concentration, concentrations[k]), keys(concentrations))
   map(k -> set_subpart!(pn′, k, :rate, rates[k]), keys(rates))
   pn′
 end
 
-LabelledReactionNet{R,C}(pn::HasPetriNet, s_labels, t_labels, concentrations, rates) where {R,C} = begin
+LabelledReactionNet{R,C}(pn::AbstractPetriNet, s_labels, t_labels, concentrations, rates) where {R,C} = begin
   pn′ = LabelledReactionNet{R,C}(pn)
   map(k -> set_subpart!(pn′, k, :sname, s_labels[k]), keys(s_labels))
   map(k -> set_subpart!(pn′, k, :tname, t_labels[k]), keys(t_labels))
@@ -558,7 +543,7 @@ LabelledReactionNet{R,C}(pn::HasPetriNet, s_labels, t_labels, concentrations, ra
   pn′
 end
 
-LabelledReactionNet{R,C}(pn::HasPetriNet, states, transitions) where {R,C} = begin
+LabelledReactionNet{R,C}(pn::AbstractPetriNet, states, transitions) where {R,C} = begin
   pn′ = LabelledReactionNet{R,C}(pn)
   for (i, (k, v)) in enumerate(states)
     set_subpart!(pn′, i, :sname, k)
@@ -571,38 +556,9 @@ LabelledReactionNet{R,C}(pn::HasPetriNet, states, transitions) where {R,C} = beg
   pn′
 end
 
-
-""" Concentration of a ReactionNet
-"""
-concentration(p::HasPetriNet, s) = subpart(p, s, :concentration)
-
-""" Rate of a RectionNet
-"""
-rate(p::HasPetriNet, t) = subpart(p, t, :rate)
-
-concentrations(p::HasPetriNet) = map(s -> concentration(p, s), 1:ns(p))
-rates(p::HasPetriNet) = map(t -> rate(p, t), 1:nt(p))
-
-""" All concentrations of a ReactionNet
-"""
-concentrations(p::LabelledReactionNet) = begin
-  snames = [sname(p, s) for s in 1:ns(p)]
-  LVector(; [(snames[s] => concentration(p, s)) for s in 1:ns(p)]...)
-end
-
-""" All rates of a ReactionNet
-"""
-rates(p::LabelledReactionNet) = begin
-  tnames = [tname(p, s) for s in 1:nt(p)]
-  LVector(; [(tnames[t] => rate(p, t)) for t in 1:nt(p)]...)
-end
-
-
-
 # PROPERTY PETRI NETS
 
-
-@abstract_acset_type AbstractPropertyPetriNet <: HasPetriNet
+@abstract_acset_type AbstractPropertyPetriNet <: AbstractPetriNet
 
 @present SchPropertyPetriNet <: SchPetriNet begin
   Prop::AttrType
@@ -611,14 +567,16 @@ end
   tprop::Attr(T, Prop)
 end
 @acset_type PropertyPetriNet(SchPropertyPetriNet, index=[:it, :is, :ot, :os]) <: AbstractPropertyPetriNet
-# const OpenPropertyPetriNetOb, OpenPropertyPetriNet = OpenCSetTypes(PropertyPetriNet, :S)
+const OpenPropertyPetriNetOb, OpenPropertyPetriNet = OpenACSetTypes(PropertyPetriNet, :S)
+Open(p::PropertyPetriNet{T}) where T = OpenPropertyPetriNet{T}(p, map(x -> FinFunction([x], ns(p)), 1:ns(p))...)
+Open(p::PropertyPetriNet{T}, legs...) where T = OpenPropertyPetriNet{T}(p, map(l -> FinFunction(l, ns(p)), legs)...)
 
 sprop(g::AbstractPropertyPetriNet, s) = subpart(g, s, :sprop)
 tprop(g::AbstractPropertyPetriNet, t) = subpart(g, t, :tprop)
 sprops(p::AbstractPropertyPetriNet) = map(s -> sprop(p, s), 1:ns(p))
 tprops(p::AbstractPropertyPetriNet) = map(t -> tprop(p, t), 1:nt(p))
 
-function (::Type{T})(pn::HasPetriNet, sprops, tprops) where T <: AbstractPropertyPetriNet
+function (::Type{T})(pn::AbstractPetriNet, sprops, tprops) where T <: AbstractPropertyPetriNet
   pn′ = T(pn)
   map(k -> set_subpart!(pn′, k, :sprop, sprops[k]), keys(sprops))
   map(k -> set_subpart!(pn′, k, :tprop, tprops[k]), keys(tprops))
@@ -634,6 +592,15 @@ end
 @acset_type PropertyLabelledPetriNetUntyped(SchPropertyLabelledPetriNet, index=[:it, :is, :ot, :os]) <: AbstractPropertyPetriNet
 const PropertyLabelledPetriNet{T} = PropertyLabelledPetriNetUntyped{Symbol,T}
 
+const OpenPropertyLabelledPetriNetObUntyped, OpenPropertyLabelledPetriNetUntyped = OpenACSetTypes(PropertyLabelledPetriNetUntyped, :S)
+const OpenPropertyLabelledPetriNetOb{T} = OpenPropertyLabelledPetriNetObUntyped{Symbol,T} 
+const OpenPropertyLabelledPetriNet{T} = OpenPropertyLabelledPetriNetUntyped{Symbol,T}
+Open(p::PropertyLabelledPetriNet{T}) where T = OpenPropertyLabelledPetriNet{T}(p, map(x -> FinFunction([x], ns(p)), 1:ns(p))...)
+Open(p::PropertyLabelledPetriNet{T}, legs...) where T = begin
+  s_idx = Dict(sname(p, s) => s for s in 1:ns(p))
+  OpenPropertyLabelledPetriNet{T}(p, map(l -> FinFunction(map(i -> s_idx[i], l), ns(p)), legs)...)
+end
+
 @present SchPropertyReactionNet <: SchReactionNet begin
   Prop::AttrType
 
@@ -641,6 +608,10 @@ const PropertyLabelledPetriNet{T} = PropertyLabelledPetriNetUntyped{Symbol,T}
   tprop::Attr(T, Prop)
 end
 @acset_type PropertyReactionNet(SchPropertyReactionNet, index=[:it, :is, :ot, :os]) <: AbstractPropertyPetriNet
+
+const OpenPropertyReactionNetOb, OpenPropertyReactionNet = OpenACSetTypes(PropertyReactionNet, :S)
+Open(p::PropertyReactionNet{R,C,T}, legs...) where {R,C,T} = OpenPropertyReactionNet{R,C,T}(p, map(l -> FinFunction(l, ns(p)), legs)...)
+Open(p::PropertyReactionNet{R,C,T}) where {R,C,T} = OpenPropertyReactionNet{R,C,T}(p, map(x -> FinFunction([x], ns(p)), 1:ns(p))...)
 
 @present SchPropertyLabelledReactionNet <: SchLabelledReactionNet begin
   Prop::AttrType
@@ -650,6 +621,60 @@ end
 end
 @acset_type PropertyLabelledReactionNetUntyped(SchPropertyLabelledReactionNet, index=[:it, :is, :ot, :os]) <: AbstractPropertyPetriNet
 const PropertyLabelledReactionNet{R,C,T} = PropertyLabelledReactionNetUntyped{R,C,Symbol,T}
+
+const OpenPropertyLabelledReactionNetObUntyped, OpenPropertyLabelledReactionNetUntyped = OpenACSetTypes(PropertyLabelledReactionNetUntyped, :S)
+const OpenPropertyLabelledReactionNetOb{R,C,T} = OpenPropertyLabelledReactionNetObUntyped{R,C,Symbol,T}
+const OpenPropertyLabelledReactionNet{R,C,T} = OpenPropertyLabelledReactionNetUntyped{R,C,Symbol,T}
+Open(p::PropertyLabelledReactionNet{R,C,T}, legs...) where {R,C,T} = begin
+  s_idx = Dict(sname(p, s) => s for s in 1:ns(p))
+  OpenPropertyLabelledReactionNet{R,C,T}(p, map(l -> FinFunction(map(i -> s_idx[i], l), ns(p)), legs)...)
+end
+Open(p::PropertyLabelledReactionNet{R,C,T}) where {R,C,T} = OpenPropertyLabelledReactionNet{R,C,T}(p, map(x -> FinFunction([x], ns(p)), 1:ns(p))...)
+
+# Add new parent types
+const AbstractLabelledPetriNet = Union{LabelledPetriNetUntyped,LabelledPetriNet,LabelledReactionNetUntyped,LabelledReactionNet,PropertyLabelledPetriNetUntyped,PropertyLabelledPetriNet,OpenPropertyLabelledReactionNetUntyped,PropertyLabelledReactionNet}
+const AbstractReactionNet = Union{ReactionNet,LabelledReactionNetUntyped,LabelledReactionNet,PropertyReactionNet,OpenPropertyLabelledReactionNetUntyped,PropertyLabelledReactionNet}
+const AbstractLabelledReactionNet = typeintersect(AbstractLabelledPetriNet, AbstractReactionNet)
+
+sname(p::AbstractLabelledPetriNet, s) = subpart(p, s, :sname)
+tname(p::AbstractLabelledPetriNet, t) = subpart(p, t, :tname)
+
+flat_symbol(sym::Symbol)::Symbol = sym
+flat_symbol(sym::Tuple)::Symbol = mapreduce(x -> isa(x, Tuple) ? flat_symbol(x) : x, (x, y) -> Symbol(x, "_", y), sym)
+
+""" flatten_labels(pn::AbstractLabelledPetriNet)
+
+Takes a labeled Petri net or reaction net and flattens arbitrarily nested labels
+on the species and the transitions to a single symbol who's previously nested
+parts are separated by `_`.
+"""
+flatten_labels(pn::AbstractLabelledPetriNet) =
+  map(pn, Name=flat_symbol)
+
+""" Concentration of a ReactionNet
+"""
+concentration(p::AbstractReactionNet, s) = subpart(p, s, :concentration)
+
+""" Rate of a RectionNet
+"""
+rate(p::AbstractReactionNet, t) = subpart(p, t, :rate)
+
+concentrations(p::AbstractReactionNet) = map(s -> concentration(p, s), 1:ns(p))
+rates(p::AbstractReactionNet) = map(t -> rate(p, t), 1:nt(p))
+
+""" All concentrations of a ReactionNet
+"""
+concentrations(p::AbstractLabelledReactionNet) = begin
+  snames = [sname(p, s) for s in 1:ns(p)]
+  LVector(; [(snames[s] => concentration(p, s)) for s in 1:ns(p)]...)
+end
+
+""" All rates of a ReactionNet
+"""
+rates(p::AbstractLabelledReactionNet) = begin
+  tnames = [tname(p, s) for s in 1:nt(p)]
+  LVector(; [(tnames[t] => rate(p, t)) for t in 1:nt(p)]...)
+end
 
 include("interoperability.jl")
 include("visualization.jl")

--- a/src/AlgebraicPetri.jl
+++ b/src/AlgebraicPetri.jl
@@ -611,8 +611,14 @@ end
 
 # PROPERTY PETRI NETS
 
+""" Abstract Type for any PetriNet ACSet with  properties.
+"""
 @abstract_acset_type AbstractPropertyPetriNet <: AbstractPetriNet
 
+""" ACSet definition for a PetriNet with properties on transitions and states.
+
+See Catlab.jl documentation for description of the @present syntax.
+"""
 @present SchPropertyPetriNet <: SchPetriNet begin
   Prop::AttrType
 
@@ -624,11 +630,26 @@ const OpenPropertyPetriNetOb, OpenPropertyPetriNet = OpenACSetTypes(PropertyPetr
 Open(p::PropertyPetriNet{T}) where T = OpenPropertyPetriNet{T}(p, map(x -> FinFunction([x], ns(p)), 1:ns(p))...)
 Open(p::PropertyPetriNet{T}, legs...) where T = OpenPropertyPetriNet{T}(p, map(l -> FinFunction(l, ns(p)), legs)...)
 
-sprop(g::AbstractPropertyPetriNet, s) = subpart(g, s, :sprop)
-tprop(g::AbstractPropertyPetriNet, t) = subpart(g, t, :tprop)
-sprops(p::AbstractPropertyPetriNet) = map(s -> sprop(p, s), 1:ns(p))
-tprops(p::AbstractPropertyPetriNet) = map(t -> tprop(p, t), 1:nt(p))
+""" Property of species
+"""
+sprop(g::AbstractPetriNet, s) = subpart(g, s, :sprop)
 
+""" Property of transition
+"""
+tprop(g::AbstractPetriNet, t) = subpart(g, t, :tprop)
+
+""" Properties of all species
+"""
+sprops(p::AbstractPetriNet) = map(s -> sprop(p, s), 1:ns(p))
+
+""" Properties of all transitions
+"""
+tprops(p::AbstractPetriNet) = map(t -> tprop(p, t), 1:nt(p))
+
+""" (::AbstractPropertyPetriNet)(pn::AbstractPetriNet, sprops, tprops)
+
+Add properties to the states and transitions of a given Petri Net.
+"""
 function (::Type{T})(pn::AbstractPetriNet, sprops, tprops) where T <: AbstractPropertyPetriNet
   pn′ = T(pn)
   map(k -> set_subpart!(pn′, k, :sprop, sprops[k]), keys(sprops))
@@ -636,6 +657,13 @@ function (::Type{T})(pn::AbstractPetriNet, sprops, tprops) where T <: AbstractPr
   pn′
 end
 
+(::Type{T})(pn::AbstractPetriNet, sprops::AbstractDict, tprops::AbstractDict) where T <: AbstractPropertyPetriNet =
+  T(pn, [sprops[sname(pn, s)] for s in 1:ns(pn)], [tprops[tname(pn, t)] for t in 1:nt(pn)])
+
+""" ACSet definition for a LabelledPetriNet with properties on transitions and states.
+
+See Catlab.jl documentation for description of the @present syntax.
+"""
 @present SchPropertyLabelledPetriNet <: SchLabelledPetriNet begin
   Prop::AttrType
 
@@ -654,6 +682,10 @@ Open(p::PropertyLabelledPetriNet{T}, legs...) where T = begin
   OpenPropertyLabelledPetriNet{T}(p, map(l -> FinFunction(map(i -> s_idx[i], l), ns(p)), legs)...)
 end
 
+""" ACSet definition for a ReactionNet with properties on transitions and states.
+
+See Catlab.jl documentation for description of the @present syntax.
+"""
 @present SchPropertyReactionNet <: SchReactionNet begin
   Prop::AttrType
 
@@ -666,6 +698,10 @@ const OpenPropertyReactionNetOb, OpenPropertyReactionNet = OpenACSetTypes(Proper
 Open(p::PropertyReactionNet{R,C,T}, legs...) where {R,C,T} = OpenPropertyReactionNet{R,C,T}(p, map(l -> FinFunction(l, ns(p)), legs)...)
 Open(p::PropertyReactionNet{R,C,T}) where {R,C,T} = OpenPropertyReactionNet{R,C,T}(p, map(x -> FinFunction([x], ns(p)), 1:ns(p))...)
 
+""" ACSet definition for a LabelledReactionNet with properties on transitions and states.
+
+See Catlab.jl documentation for description of the @present syntax.
+"""
 @present SchPropertyLabelledReactionNet <: SchLabelledReactionNet begin
   Prop::AttrType
 

--- a/src/BilayerNetworks.jl
+++ b/src/BilayerNetworks.jl
@@ -73,18 +73,25 @@ function migrate!(bn::AbstractBilayerNetwork, pn::AbstractPetriNet)
                   :infusion=>:os))
 end
 
-function migrate!(bn::AbstractLabelledBilayerNetwork, pn::AbstractLabelledPetriNet)
-    migrate!(bn, pn,
-             Dict(:Qin=>:S, :Qout=>:S, :Box=>:T, :Win=>:I, :Wn=>:I, :Wa=>:O, :Name=>:Name),
-             Dict(:arg=>:is,
-                  :call=>:it,
-                  :efflux=>:it,
-                  :effusion=>:is,
-                  :influx=>:ot,
-                  :infusion=>:os,
-                  :parameter=>:tname,
-                  :variable=>:sname,
-                  :tanvar=>:sname))
+function migrate!(bn::AbstractLabelledBilayerNetwork, pn::AbstractPetriNet)
+    generators = Dict(:Qin=>:S, :Qout=>:S, :Box=>:T, :Win=>:I, :Wn=>:I, :Wa=>:O)
+    parts = Dict(:arg=>:is,
+                 :call=>:it,
+                 :efflux=>:it,
+                 :effusion=>:is,
+                 :influx=>:ot,
+                 :infusion=>:os)
+    if :Name in attrtypes(acset_schema(pn))
+        generators[:Name] = :Name
+    end
+    if has_subpart(pn, :sname)
+        parts[:variable] = :sname
+        parts[:tanvar] = :sname
+    end
+    if has_subpart(pn, :tname)
+        parts[:parameter] = :tname
+    end
+    migrate!(bn, pn, generators, parts)
 end
 
 
@@ -99,17 +106,24 @@ function migrate!(pn::AbstractPetriNet, bn::AbstractBilayerNetwork)
               :os=>:infusion))
 end
 
-function migrate!(pn::AbstractLabelledPetriNet, bn::AbstractLabelledBilayerNetwork)
+function migrate!(pn::AbstractPetriNet, bn::AbstractLabelledBilayerNetwork)
     bnc = copy(bn)
     balance!(bnc)
-    migrate!(pn,bnc,
-         Dict(:S=>:Qin, :T=>:Box, :I=>:Win, :O=>:Wa, :Name=>:Name),
-         Dict(:is=>:arg,
-              :it=>:call,
-              :ot=>:influx,
-              :os=>:infusion,
-              :tname=>:parameter,
-              :sname=>:variable))
+    generators = Dict(:S=>:Qin, :T=>:Box, :I=>:Win, :O=>:Wa)
+    parts = Dict(:is=>:arg,
+                 :it=>:call,
+                 :ot=>:influx,
+                 :os=>:infusion)
+    if :Name in attrtypes(acset_schema(pn))
+        generators[:Name] = :Name
+    end
+    if has_subpart(pn, :sname)
+        parts[:sname] = :variable
+    end
+    if has_subpart(pn, :tname)
+        parts[:tname] = :parameter
+    end
+    migrate!(pn, bnc, generators, parts)
 end
 
 

--- a/src/ModelingToolkitInterop.jl
+++ b/src/ModelingToolkitInterop.jl
@@ -49,12 +49,7 @@ module ModelingToolkitInterop
     ODESystem(eqs, t, S, r; name=name, kws...)
   end
 
-  function ModelingToolkit.ODEProblem(
-    p::Union{AbstractReactionNet, AbstractLabelledReactionNet},
-    tspan;
-    name=:PetriNet,
-    kwargs...
-  )
+  function ModelingToolkit.ODEProblem(p::AbstractPetriNet, tspan; name=:PetriNet, kwargs...)
     sys = ODESystem(p; name)
     ODEProblem(sys, p[:,:concentration], tspan, p[:,:rate]; kwargs...)
   end
@@ -70,7 +65,7 @@ module ModelingToolkitInterop
   default to preserve the bilayer structure. This is useful when one wants to
   convert symbolic expressions back to a bilayer network.
   """
-  function ModelingToolkit.ODESystem(bn::Union{AbstractLabelledBilayerNetwork,AbstractBilayerNetwork}; name=:BilayerNetwork, simplify = false)
+  function ModelingToolkit.ODESystem(bn::AbstractBilayerNetwork; name=:BilayerNetwork, simplify = false)
     t = (@variables t)[1]
     D = Differential(t)
     symbolic_vars = map(bn[:variable]) do v

--- a/src/OpenTransitions.jl
+++ b/src/OpenTransitions.jl
@@ -4,8 +4,7 @@
 module OpenTransitions
 
 using AlgebraicPetri: 
-    LabelledPetriNetUntyped, PetriNet, AbstractPetriNet, 
-    AbstractLabelledPetriNet, 
+    LabelledPetriNetUntyped, LabelledPetriNet, PetriNet, AbstractPetriNet, 
     ns, nt, tname
 using Catlab
 using Catlab.CategoricalAlgebra
@@ -37,11 +36,11 @@ OpenT(n, p::AbstractPetriNet, m) = OpenT(p, n, m)
 const OpenLabelledPetriNetObUntypedT, OpenLabelledPetriNetUntypedT = OpenACSetTypes(LabelledPetriNetUntyped,:T)
 const OpenLabelledPetriNetObT, OpenLabelledPetriNetT = OpenLabelledPetriNetObUntypedT{Symbol}, OpenLabelledPetriNetUntypedT{Symbol}
 
-OpenT(p::AbstractLabelledPetriNet) = OpenLabelledPetriNetT(p, map(x->FinFunction([x], nt(p)), 1:nt(p))...)
-OpenT(p::AbstractLabelledPetriNet, legs...) = begin
+OpenT(p::LabelledPetriNet) = OpenLabelledPetriNetT(p, map(x->FinFunction([x], nt(p)), 1:nt(p))...)
+OpenT(p::LabelledPetriNet, legs...) = begin
     t_idx = Dict(tname(p, t)=>t for t in 1:nt(p))
     OpenLabelledPetriNetT(p, map(l->FinFunction(map(i->t_idx[i], l), nt(p)), legs)...)
 end
-OpenT(n, p::AbstractLabelledPetriNet, m) = OpenT(p, n, m)
+OpenT(n, p::LabelledPetriNet, m) = OpenT(p, n, m)
 
 end

--- a/src/SubACSets.jl
+++ b/src/SubACSets.jl
@@ -12,7 +12,7 @@ using AlgebraicPetri
 
 concatmap(f,xs) = mapreduce(f, vcat, xs; init =[])
 
-function strip_names(p::AbstractLabelledPetriNet)
+function strip_names(p::AbstractPetriNet)
   map(p, Name = name -> nothing)
 end
 

--- a/src/TypedPetri.jl
+++ b/src/TypedPetri.jl
@@ -132,7 +132,7 @@ function add_reflexives(
       type_ind = findfirst(==(ct), type_system[:tname])
       is, os = [incident(type_system, type_ind, f) for f in [:it, :ot]]
       new_t = add_part!(petri, :T; tname=ct)
-      if petri isa AbstractLabelledReactionNet
+      if has_subpart(petri, :rate)
         set_subpart!(petri, new_t, :rate, 1.0)
       end
       add_parts!(petri, :I, length(is); is=s_i, it=new_t)
@@ -146,7 +146,8 @@ function add_reflexives(
     codom(typed_petri);
     type_comps...,
     Name=x->nothing,
-    (petri isa AbstractLabelledReactionNet ? [:Rate=>x->nothing, :Concentration=>x->nothing] : [])...
+    (has_subpart(petri, :rate) ? [:Rate=>x->nothing] : [])...,
+    (has_subpart(petri, :concentration) ? [:Concentration=>x->nothing] : [])...
   )
 end
 

--- a/src/interoperability.jl
+++ b/src/interoperability.jl
@@ -7,22 +7,22 @@ function __init__()
     # Interoperability with Petri.jl
     Petri.Model(p::AbstractPetriNet) = begin
       ts = TransitionMatrices(p)
-      t_in = map(i->Dict(k=>v for (k,v) in enumerate(ts.input[i,:]) if v != 0), 1:nt(p))
-      t_out = map(i->Dict(k=>v for (k,v) in enumerate(ts.output[i,:]) if v != 0), 1:nt(p))
 
-      Δ = Dict(i=>t for (i,t) in enumerate(zip(t_in, t_out)))
+      if has_subpart(p, :sname) && has_subpart(p, :tname)
+        snames = [sname(p, s) for s in 1:ns(p)]
+        tnames = [tname(p, t) for t in 1:nt(p)]
+        t_in = map(i->LVector(;[(snames[k]=>v) for (k,v) in enumerate(ts.input[i,:]) if v != 0]...), 1:nt(p))
+        t_out = map(i->LVector(;[(snames[k]=>v) for (k,v) in enumerate(ts.output[i,:]) if v != 0]...), 1:nt(p))
+        Δ = LVector(;[(tnames[i]=>t) for (i,t) in enumerate(zip(t_in, t_out))]...)
+        S = collect(values(snames)) 
+      else
+        t_in = map(i->Dict(k=>v for (k,v) in enumerate(ts.input[i,:]) if v != 0), 1:nt(p))
+        t_out = map(i->Dict(k=>v for (k,v) in enumerate(ts.output[i,:]) if v != 0), 1:nt(p))
+        Δ = Dict(i=>t for (i,t) in enumerate(zip(t_in, t_out)))
+        S = ns(p)
+      end
+
       return Petri.Model(ns(p), Δ)
-    end
-
-    Petri.Model(p::Union{AbstractLabelledPetriNet, AbstractLabelledReactionNet}) = begin
-      snames = [sname(p, s) for s in 1:ns(p)]
-      tnames = [tname(p, t) for t in 1:nt(p)]
-      ts = TransitionMatrices(p)
-      t_in = map(i->LVector(;[(snames[k]=>v) for (k,v) in enumerate(ts.input[i,:]) if v != 0]...), 1:nt(p))
-      t_out = map(i->LVector(;[(snames[k]=>v) for (k,v) in enumerate(ts.output[i,:]) if v != 0]...), 1:nt(p))
-
-      Δ = LVector(;[(tnames[i]=>t) for (i,t) in enumerate(zip(t_in, t_out))]...)
-      return Petri.Model(collect(values(snames)), Δ)
     end
   end
 

--- a/test/bilayernetworks.jl
+++ b/test/bilayernetworks.jl
@@ -71,7 +71,7 @@ function roundtrip(pn::AbstractPetriNet, bn::AbstractBilayerNetwork)
     return roundtrippetri, pn_structure
 end
 
-function roundtrip(pn::AbstractLabelledPetriNet, bn::AbstractLabelledBilayerNetwork)
+function roundtrip(pn::AbstractPetriNet, bn::AbstractLabelledBilayerNetwork)
     roundtrippetri = LabelledPetriNet()
     migrate!(roundtrippetri, bn)
     return roundtrippetri, pn

--- a/test/types.jl
+++ b/test/types.jl
@@ -129,3 +129,45 @@ for tuple_petri in [tuple_labelled, tuple_rxn]
   @test tuple_petri′[:, :sname] == [:U_S, :U_I, :U_R]
   @test tuple_petri′[:, :tname] == [:Q_inf, :Q_rec]
 end
+
+# Property Petri Nets
+sir_petri = PetriNet(3, ((1, 2), (2, 2)), (2, 3))
+sir_lpetri = LabelledPetriNet([:S, :I, :R], :inf => ((:S, :I), (:I, :I)), :rec => (:I, :R))
+sir_rxn = ReactionNet{Function,Int}([990, 10, 0], (β) => ((1, 2) => (2, 2)), (t -> γ) => (2 => 3))
+sir_lrxn = LabelledReactionNet{Number,Int}((:S => 990, :I => 10, :R => 0), (:inf, 0.001) => ((:S, :I) => (:I, :I)), (:rec, 0.25) => (:I => :R))
+
+sir_sprops = [
+  Dict(:title => "Susceptible", :unit => "People"),
+  Dict(:title => "Infected", :unit => "People"),
+  Dict(:title => "Recovered", :unit => "People"),
+]
+sir_sprops_dict = Dict(:S => sir_sprops[1], :I => sir_sprops[2], :R => sir_sprops[3])
+
+sir_tprops = [
+  Dict(:title => "Infection", :description => "An infected person interacts with a suscpetible person and the susceptible person becomes infected."),
+  Dict(:title => "Recovery", :description => "An infected person recovers from their illness."),
+]
+sir_tprops_dict = Dict(:inf => sir_tprops[1], :rec => sir_tprops[2])
+
+sir_proppetri = PropertyPetriNet{Dict}(sir_petri, sir_sprops, sir_tprops)
+@test PetriNet(sir_proppetri) == sir_petri
+
+@test sir_sprops == sprops(sir_proppetri)
+@test sir_tprops == tprops(sir_proppetri)
+
+sir_proplpetri = PropertyLabelledPetriNet{Dict}(sir_lpetri, sir_sprops_dict, sir_tprops_dict)
+@test LabelledPetriNet(sir_proplpetri) == sir_lpetri
+
+sir_proprxn = PropertyReactionNet{Function,Int,Dict}(sir_rxn, sir_sprops, sir_tprops)
+@test ReactionNet{Function,Int}(sir_proprxn) == sir_rxn
+
+sir_proplrxn = PropertyLabelledReactionNet{Number,Int,Dict}(sir_lrxn, sir_sprops_dict, sir_tprops_dict)
+@test LabelledReactionNet{Number,Int}(sir_proplrxn) == sir_lrxn
+
+for p in [sir_proppetri, sir_proprxn]
+  @test Open(p, [1], [2], [3]) == Open(p)
+end
+
+for p in [sir_proplpetri, sir_proplrxn]
+  @test Open(p, [:S], [:I], [:R]) == Open(p)
+end


### PR DESCRIPTION
### TODO

- [x] Finalize implementation and make sure all the cases are covered
- [x] Add testing
- [x] ~Split up `src/AlgebraicPetri.jl` This one file is getting unruly at this point and this seems like a good point to just refactor the types of petri nets into their own files~ punt on this to another PR

The main goal of this PR is to add support for Petri Nets with arbitrary metadata added to them. This also cleans up some of our types and generalizes a lot of our functions to make sure that they work on all types of petri net acsets. 