### PR TITLE
Allow `vectorfield_expr` work with more types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,6 @@ Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 GeneralizedGenerated = "6b9d7cbe-bcb9-11e9-073f-15a7a543e2eb"
 LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 


### PR DESCRIPTION
Originally was trying to drop `labelled_arrays` from AlgebraicPetri's dependencies, but it turns out DifferentialEquations.jl doesn't support dictionaries of initial conditions... so I suppose we are stuck with this as a dependency if we want to have named results. One thing that this did allow was for us to generalize our `vectorfield` functions a bit. While DifferentialEquations.jl maybe doesn't support it, it's good for our functions to be as general as they can be.