### PR TITLE
Changed `prim_petri` to fix issue when type system has multiple states.

### DIFF
--- a/src/TypedPetri.jl
+++ b/src/TypedPetri.jl
@@ -19,16 +19,14 @@ function prim_petri(type_system, transition)
   t = add_transition!(prim)
   s_map = Int[]
   for i in inputs(type_system, transition)
-    s = is(type_system, i)
-    s′ = add_species!(prim)
-    push!(s_map, s)
-    add_input!(prim, 1, s′)
+    i′ = add_species!(prim)
+    push!(s_map, i)
+    add_input!(prim, 1, i′)
   end
-  for i in outputs(type_system, transition)
-    s = os(type_system, i)
-    s′ = add_species!(prim)
-    push!(s_map, s)
-    add_output!(prim, 1, s′)
+  for o in outputs(type_system, transition)
+    o′ = add_species!(prim)
+    push!(s_map, o)
+    add_output!(prim, 1, o′)
   end
   ACSetTransformation(
     prim,


### PR DESCRIPTION
This change attempts to address an issue with `prim_petri`. It appears the states of the type system (`s_map`) were not being determined correctly. It did not arise as an issue before because most examples use a type system with only a single state, but in recent examples with multiple type states, the typing has been incorrect. 

Resolves #142