### PR TITLE
cleanup!: drop support for julia <1.9 and remove requires

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,14 +9,12 @@ Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 GeneralizedGenerated = "6b9d7cbe-bcb9-11e9-073f-15a7a543e2eb"
 LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [weakdeps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 Petri = "4259d249-1051-49fa-8328-3f8ab9391c33"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"        # makes sure Requires isn't a dependency for Julia v1.9+
 
 [extensions]
 AlgebraicPetriPetriExt = "Petri"
@@ -31,6 +29,5 @@ GeneralizedGenerated = "0.3"
 LabelledArrays = "1"
 ModelingToolkit = "8"
 Petri = "1"
-Requires = "1"
 StatsBase = "0.33,0.34"
-julia = "1.6"
+julia = "1.9"

--- a/ext/AlgebraicPetriCatalystExt.jl
+++ b/ext/AlgebraicPetriCatalystExt.jl
@@ -2,16 +2,9 @@ module AlgebraicPetriCatalystExt
 
 using AlgebraicPetri
 using Catlab.CategoricalAlgebra
-# TODO: Remove after dropping support for <Julia 1.9
-if isdefined(Base, :get_extension)
-  using Catalyst
-  using Catalyst.Symbolics: scalarize
-  import Catalyst: ReactionSystem
-else
-  using ..Catalyst
-  using ..Catalyst.Symbolics: scalarize
-  import ..Catalyst: ReactionSystem
-end
+using Catalyst
+using Catalyst.Symbolics: scalarize
+import Catalyst: ReactionSystem
 
 counter(a) = [count(==(i),a) for i in unique(a)]
 

--- a/ext/AlgebraicPetriModelingToolkitExt.jl
+++ b/ext/AlgebraicPetriModelingToolkitExt.jl
@@ -3,14 +3,8 @@ module AlgebraicPetriModelingToolkitExt
 using AlgebraicPetri
 using AlgebraicPetri.BilayerNetworks
 using Catlab.CategoricalAlgebra: has_subpart, incident, parts
-# TODO: Remove after dropping support for <Julia 1.9
-if isdefined(Base, :get_extension)
-  using ModelingToolkit
-  import ModelingToolkit: ODESystem
-else
-  using ..ModelingToolkit
-  import ..ModelingToolkit: ODESystem
-end
+using ModelingToolkit
+import ModelingToolkit: ODESystem
 
 
 """ Convert a general PetriNet to an ODESystem

--- a/ext/AlgebraicPetriPetriExt.jl
+++ b/ext/AlgebraicPetriPetriExt.jl
@@ -3,8 +3,7 @@ module AlgebraicPetriPetriExt
 using AlgebraicPetri
 using Catlab.CategoricalAlgebra
 
-# TODO: Remove after dropping support for <Julia 1.9
-isdefined(Base, :get_extension) ? (import Petri) : (import ..Petri)
+import Petri
 
 Petri.Model(p::AbstractPetriNet) = begin
   ts = TransitionMatrices(p)

--- a/src/AlgebraicPetri.jl
+++ b/src/AlgebraicPetri.jl
@@ -772,7 +772,4 @@ include("SubACSets.jl")
 include("TypedPetri.jl")
 include("OpenTransitions.jl")
 
-# TODO: Remove after dropping support for <Julia 1.9
-if !isdefined(Base, :get_extension) include("interoperability.jl") end
-
 end

--- a/src/interoperability.jl
+++ b/src/interoperability.jl
@@ -1,7 +1,0 @@
-using Requires
-
-function __init__()
-  @require Petri="4259d249-1051-49fa-8328-3f8ab9391c33" include("../ext/AlgebraicPetriPetriExt.jl")
-  @require Catalyst="479239e8-5488-4da2-87a7-35f2df7eef83" include("../ext/AlgebraicPetriCatalystExt.jl")
-  @require ModelingToolkit="961ee093-0014-501f-94e3-6117800e7a78" include("../ext/AlgebraicPetriModelingToolkitExt.jl")
-end


### PR DESCRIPTION
This is paving the way for the upcoming v0.9 release along with Catlab v0.15 which will remove Julia <v1.9 support so we are following along with that.