### PR TITLE
refactor!: move to `to_graphviz` for visualization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,6 @@ Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 GeneralizedGenerated = "6b9d7cbe-bcb9-11e9-073f-15a7a543e2eb"
 LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [weakdeps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
@@ -29,5 +28,4 @@ GeneralizedGenerated = "0.3"
 LabelledArrays = "1"
 ModelingToolkit = "8"
 Petri = "1"
-StatsBase = "0.33,0.34"
 julia = "1.9"

--- a/docs/literate/covid/_covid.jl
+++ b/docs/literate/covid/_covid.jl
@@ -61,7 +61,7 @@ seird_city = to_hom_expr(FreeBiproductCategory, seird_city)
 
 display_wd(seird_city)
 # -
-Graph(decoration(F(seird_city)))
+to_graphviz(decoration(F(seird_city)))
 
 # create a multi-city SEIRD models
 
@@ -72,7 +72,7 @@ pc_seird_3 = F(seird_3)
 p_seird_3 = decoration(pc_seird_3)
 display_wd(seird_3)
 # -
-Graph(p_seird_3)
+to_graphviz(p_seird_3)
 
 # Define time frame and initial parameters
 

--- a/docs/literate/covid/_generate_figs.jl
+++ b/docs/literate/covid/_generate_figs.jl
@@ -2,6 +2,7 @@
 include("epidemiology.jl")
 
 using OrdinaryDiffEq
+using Catlab.Graphics
 using Catlab.Graphics.Graphviz: run_graphviz
 
 # +
@@ -41,7 +42,7 @@ end
 # -
 
 save_wd(sir, "sir.svg")
-save_graph(Graph(p_sir), "sir_graph.svg")
+save_graph(to_graphviz(p_sir), "sir_graph.svg")
 
 # define initial states and transition rates
 u0 = [10.0, 1, 0]
@@ -53,7 +54,7 @@ sol = OrdinaryDiffEq.solve(prob,Tsit5())
 splot(sol, "sir_soln.svg")
 
 save_wd(seir, "seir.svg")
-save_graph(Graph(p_seir), "seir_graph.svg")
+save_graph(to_graphviz(p_seir), "seir_graph.svg")
 
 # define initial states and transition rates
 u0 = [10.0, 1, 0, 0]
@@ -65,7 +66,7 @@ sol = OrdinaryDiffEq.solve(prob,Tsit5())
 splot(sol, "seir_soln.svg")
 
 save_wd(seird, "seird.svg")
-save_graph(Graph(p_seird), "seird_graph.svg")
+save_graph(to_graphviz(p_seird), "seird_graph.svg")
 
 # define initial states and transition rates
 u0 = [10.0, 1, 0, 0, 0]
@@ -78,16 +79,16 @@ splot(sol, "seird_soln.svg")
 
 include("covid.jl")
 
-[save_graph(Graph(Petri.Model(decoration(p))), pname) for (p,pname) in [(spontaneous_petri, "spont.svg"),
+[save_graph(to_graphviz(Petri.Model(decoration(p))), pname) for (p,pname) in [(spontaneous_petri, "spont.svg"),
                                                (transmission_petri, "transmission.svg"),
                                                (exposure_petri, "exposure.svg"),
                                                (travel_petri, "travel.svg")]]
 
 save_wd(seird_city, "seird_city.svg")
-save_graph(Graph(Petri.Model(decoration(F(seird_city)))), "seird_graph.svg")
+save_graph(to_graphviz(Petri.Model(decoration(F(seird_city)))), "seird_graph.svg")
 
 save_wd(seird_3, "seird_3.svg")
-save_graph(Graph(p_seird_3), "seird_3_graph.svg")
+save_graph(to_graphviz(p_seird_3), "seird_3_graph.svg")
 
 pltdims = [4,9, 14]
 # Define time frame, 3 months

--- a/docs/literate/covid/bilayerconversion.jl
+++ b/docs/literate/covid/bilayerconversion.jl
@@ -43,7 +43,7 @@ display_uwd(sir)
 # Extract the Petri network form of the model.
 psir = apex(oapply_epi(sir))
 psir
-Graph(psir)
+to_graphviz(psir)
 #-
 
 # Convert the Petri network into a bilayer network and draw it.
@@ -106,7 +106,7 @@ bnrt,pnstr = roundtrip(pseir, bnseir)
 
 display_uwd(sir)
 
-Graph(psir)
+to_graphviz(psir)
 #-
 
 to_graphviz(bnsir)
@@ -115,7 +115,7 @@ to_graphviz(bnsir)
 to_graphviz(bnseir)
 #-
 
-Graph(bnrt)
+to_graphviz(bnrt)
 #-
 
 qm = @relation (s,q) begin
@@ -140,7 +140,7 @@ semantics = Dict(
     :quarrec   => spontaneous_petri(:Q, :R, :qr)
 )
 pn_quar = oapply(qm, semantics)  |> apex
-Graph(pn_quar)
+to_graphviz(pn_quar)
 #-
 
 bnquar = LabelledBilayerNetwork()
@@ -159,7 +159,7 @@ display_uwd(qm)
 #-
 
 pn_quar = oapply(qm, semantics)  |> apex
-Graph(pn_quar)
+to_graphviz(pn_quar)
 #-
 
 bnquar = LabelledBilayerNetwork()
@@ -168,7 +168,7 @@ to_graphviz(bnquar)
 #-
 
 quarrt = LabelledPetriNet()
-migrate!(quarrt, bnquar) |> Graph
+migrate!(quarrt, bnquar) |> to_graphviz
 
 bnquar
 #-

--- a/docs/literate/covid/chime/chime-cset.jl
+++ b/docs/literate/covid/chime/chime-cset.jl
@@ -3,6 +3,7 @@ using OrdinaryDiffEq
 using Plots
 using Catlab.Meta
 using Catlab.CategoricalAlgebra
+using Catlab.Graphics
 using JSON
 
 import OrdinaryDiffEq: ODEProblem
@@ -27,7 +28,7 @@ end
 
 sir_cset= LabelledReactionNet{Function, Float64}((:S=>990, :I=>10, :R=>0), (:inf, β)=>((:S, :I)=>(:I,:I)), (:rec, t->γ)=>(:I=>:R))
 
-Graph(sir_cset)
+to_graphviz(sir_cset)
 
 prob = ODEProblem(sir_cset, (17.0, 120.0))
 sol = OrdinaryDiffEq.solve(prob,Tsit5())

--- a/docs/literate/covid/chime/chime.jl
+++ b/docs/literate/covid/chime/chime.jl
@@ -20,7 +20,7 @@ display_uwd(sir)
 
 #-
 p_sir = apex(oapply_epi(sir));
-Graph(p_sir)
+to_graphviz(p_sir)
 
 u0 = LVector(S=990, I=10, R=0);
 t_span = (17.0,120.0)

--- a/docs/literate/covid/coexist/coexist.jl
+++ b/docs/literate/covid/coexist/coexist.jl
@@ -164,8 +164,8 @@ end;
 display_uwd(threeNCoexist)
 #-
 threeNCoexist_algpetri = apex(F_tcx(threeNCoexist))
-Graph(threeNCoexist_algpetri);
-save_fig(Graph(threeNCoexist_algpetri), "3ncoexist_petri", "svg"); # hide
+to_graphviz(threeNCoexist_algpetri);
+save_fig(to_graphviz(threeNCoexist_algpetri), "3ncoexist_petri", "svg"); # hide
 
 # ![3-generation COEXIST model petri net](3ncoexist_petri.svg)
 

--- a/docs/literate/covid/epidemiology.jl
+++ b/docs/literate/covid/epidemiology.jl
@@ -27,7 +27,7 @@ end
 display_uwd(sir)
 #-
 p_sir = apex(oapply_epi(sir))
-Graph(p_sir)
+to_graphviz(p_sir)
 
 # define initial states and transition rates, then
 # create, solve, and visualize ODE problem
@@ -53,7 +53,7 @@ end
 display_uwd(seir)
 #-
 p_seir = apex(oapply_epi(seir))
-Graph(p_seir)
+to_graphviz(p_seir)
 
 # define initial states and transition rates, then
 # create, solve, and visualize ODE problem
@@ -78,7 +78,7 @@ end
 display_uwd(seird)
 #-
 p_seird = apex(oapply_epi(seird))
-Graph(p_seird)
+to_graphviz(p_seird)
 
 # define initial states and transition rates, then
 # create, solve, and visualize ODE problem

--- a/docs/literate/covid/stratification/stratification.jl
+++ b/docs/literate/covid/stratification/stratification.jl
@@ -19,7 +19,7 @@ const infectious_ontology = LabelledPetriNet(
   :strata => (:Pop => :Pop)
 )
 
-Graph(infectious_ontology)
+to_graphviz(infectious_ontology)
 
 # Define a simple SIRD model with reflexive transitions typed as `:strata` to indicate which states can be stratified
 # Here we add reflexive transitions to the susceptible, infected, and recovered populations but we leave out the dead
@@ -34,7 +34,7 @@ end
 sird_model = oapply_typed(infectious_ontology, sird_uwd, [:infection, :recovery, :death])
 sird_model = add_reflexives(sird_model, [[:strata], [:strata], [:strata], []], infectious_ontology)
 
-Graph(dom(sird_model))
+to_graphviz(dom(sird_model))
 
 # ## Define intervention models
 
@@ -49,11 +49,11 @@ end
 mask_model = oapply_typed(infectious_ontology, masking_uwd, [:unmask, :mask, :infect_um, :infect_uu])
 mask_model = add_reflexives(mask_model, [[:strata], [:strata]], infectious_ontology)
 
-Graph(dom(mask_model))
+to_graphviz(dom(mask_model))
 
 # Stratify our SIRD model on this masking model to get a model of SIRD with masking:
 
-typed_product(sird_model, mask_model) |> dom |> Graph
+typed_product(sird_model, mask_model) |> dom |> to_graphviz
 
 # ### Vaccine model
 
@@ -67,11 +67,11 @@ end
 vax_model = oapply_typed(infectious_ontology, vax_uwd, [:vax, :infect_vv, :infect_uv, :infect_vu, :infect_uu])
 vax_model = add_reflexives(vax_model, [[:disease], [:disease]], infectious_ontology)
 
-Graph(dom(vax_model))
+to_graphviz(dom(vax_model))
 
 # Stratify our SIRD model on this vaccine model to get a model of SIRD with a vaccination rate:
 
-typed_product(sird_model, vax_model) |> dom |> Graph
+typed_product(sird_model, vax_model) |> dom |> to_graphviz
 
 # ### Mask-Vax Model
 
@@ -98,11 +98,11 @@ mask_vax_model = oapply_typed(
 )
 mask_vax_model = add_reflexives(mask_vax_model, [[:disease], [:disease], [:disease], [:disease]], infectious_ontology)
 
-Graph(dom(mask_vax_model))
+to_graphviz(dom(mask_vax_model))
 
 # Stratify our SIRD model on this mask + vaccine model to get a model of SIRD with a vaccination rate and masking policies:
 
-typed_product(sird_model, mask_vax_model) |> dom |> Graph
+typed_product(sird_model, mask_vax_model) |> dom |> to_graphviz
 
 # ## Define geographic models
 
@@ -131,11 +131,11 @@ function travel_model(n)
   add_reflexives(act, repeat([[:infect, :disease]], n), infectious_ontology)
 end
 
-Graph(dom(travel_model(2)))
+to_graphviz(dom(travel_model(2)))
 
 # Stratify our SIRD model on this travel model with two regions:
 
-typed_product(sird_model, travel_model(2)) |> dom |> Graph
+typed_product(sird_model, travel_model(2)) |> dom |> to_graphviz
 
 # ### Simple Trip model between $N$ regions
 
@@ -148,16 +148,16 @@ function living_model(n)
   add_reflexives(typed_living, repeat([[:disease, :strata]], n), infectious_ontology)
 end
 
-Graph(dom(living_model(2)))
+to_graphviz(dom(living_model(2)))
 
 # The resulting simple trip model:
 
 simple_trip_model = typed_product(travel_model(2), living_model(2))
-Graph(dom(simple_trip_model))
+to_graphviz(dom(simple_trip_model))
 
 # Stratify our SIRD model on this simple trip model between two regions:
 
-typed_product(sird_model, simple_trip_model) |> dom |> Graph
+typed_product(sird_model, simple_trip_model) |> dom |> to_graphviz
 
 # ## Stratification of COVID models
 
@@ -191,7 +191,7 @@ m1_model = (@relation () where {(S::Pop, I::Pop, D::Pop, A::Pop, R::Pop, T::Pop,
   disease(T, H)
 end) |> oapply_mira_model
 
-Graph(dom(m1_model))
+to_graphviz(dom(m1_model))
 
 # ### SEIAHRD Model
 #
@@ -212,7 +212,7 @@ m2_model = (@relation () where {(S::Pop, E::Pop, I::Pop, A::Pop, H::Pop, R::Pop,
   disease(H, R)
 end) |> oapply_mira_model
 
-Graph(dom(m2_model))
+to_graphviz(dom(m2_model))
 
 # ### SEIuIrQRD Model
 #
@@ -232,7 +232,7 @@ m3_model = (@relation () where {(S::Pop, E::Pop, Iu::Pop, Ir::Pop, Q::Pop, R::Po
   disease(Ir, D)
 end) |> oapply_mira_model
 
-Graph(dom(m3_model))
+to_graphviz(dom(m3_model))
 
 # ### Enumerating stratified models
 #
@@ -260,4 +260,4 @@ Markdown.parse(join(table, "\n")) |> DisplayAs.HTML
 # number of states and transitions increase polynomially which causes the execution time
 # for calculating the final stratified model to also increase polynomially.
 #
-# ![Runtime vs. Number of Georgraphic Regions](../../../../assets/runtime_vs_num_rgns.svg)
+# ![Runtime vs. Number of Georgraphic Regions](../../../assets/runtime_vs_num_rgns.svg)

--- a/docs/literate/predation/lotka-volterra.jl
+++ b/docs/literate/predation/lotka-volterra.jl
@@ -18,13 +18,13 @@ display_uwd(ex) = to_graphviz(ex, box_labels=:name, junction_labels=:variable, e
 # #### Step 1: Define the building block Petri nets needed to construct the model
 
 birth_petri = Open(PetriNet(1, 1=>(1,1)));
-Graph(birth_petri)
+to_graphviz(birth_petri)
 #-
 predation_petri = Open(PetriNet(2, (1,2)=>(2,2)));
-Graph(predation_petri)
+to_graphviz(predation_petri)
 #-
 death_petri = Open(PetriNet(1, 1=>()));
-Graph(death_petri)
+to_graphviz(death_petri)
 
 
 # #### Step 2: Generate models using a relational syntax
@@ -38,7 +38,7 @@ display_uwd(lotka_volterra)
 #-
 lv_dict = Dict(:birth=>birth_petri, :predation=>predation_petri, :death=>death_petri);
 lotka_petri = apex(oapply(lotka_volterra, lv_dict))
-Graph(lotka_petri)
+to_graphviz(lotka_petri)
 
 # Generate appropriate vector fields, define parameters, and visualize solution
 
@@ -61,7 +61,7 @@ end
 display_uwd(dual_lv)
 #-
 dual_lv_petri = apex(oapply(dual_lv, lv_dict))
-Graph(dual_lv_petri)
+to_graphviz(dual_lv_petri)
 
 # Generate a new solver, provide parameters, and analyze results
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,177 +1,163 @@
-using Catlab.CategoricalAlgebra
-using Catlab.Graphics.Graphviz
-import Catlab.Graphics.Graphviz: Graph, Subgraph
-import Base.Iterators: flatten
-using StatsBase
+using Catlab.CategoricalAlgebra, Catlab.Graphics.Graphviz
+using Catlab.Graphs: PropertyGraph
 
-export Graph
+import Catlab.Graphics.Graphviz: Subgraph
+import Catlab.Graphics: to_graphviz, to_graphviz_property_graph
 
-###########################
-# Base Graph Construction #
-###########################
-def_states(p, s; pos="") = ("s$s", Attributes(:label=>"$(sname(p, s))",
-                                              :shape=>"circle",
-                                              :color=>"#6C9AC3",
-                                              :pos=>pos))
-def_trans(p, t; pos="") = ("t$t", Attributes(:label=>"$(tname(p, t))",
-                                             :shape=>"square",
-                                             :color=>"#E28F41",
-                                             :pos=>pos))
-def_inpts(p, s, t, i) = (["s$s", "t$t"],Attributes(:labelfontsize=>"6"))
-def_otpts(p, s, t, o) = (["t$t", "s$s"],Attributes(:labelfontsize=>"6"))
+const GRAPH_ATTRS = Dict(:rankdir=>"LR")
+const NODE_ATTRS = Dict(:shape => "plain", :style=>"filled")
+const EDGE_ATTRS = Dict(:splines=>"splines")
 
-function Graph(p::AbstractPetriNet; make_states::Function=def_states,
-               make_trans::Function=def_trans, make_inpts::Function=def_inpts,
-               make_otpts::Function=def_otpts, name="G", prog="dot",
-               positions=Dict(:T=>fill("", nt(p)), :S=>fill("", ns(p))), kw...)
 
-  graph_attrs = :graph_attrs ∈ keys(kw) ? Attributes(kw[:graph_attrs]) :
-                                          Attributes(:rankdir=>"LR")
-  node_attrs  = :node_attrs ∈ keys(kw) ? Attributes(kw[:node_attrs]) :
-                                         Attributes(:shape=>"plain",
-                                                    :style=>"filled",
-                                                    :color=>"white")
-  edge_attrs  = :edge_attrs ∈ keys(kw) ? Attributes(kw[:edge_attrs]) :
-                                         Attributes(:splines=>"splines")
+# Single Petri Nets
+###################
 
-  statenodes = [Node(make_states(p,s; pos=positions[:S][s])...) for s in 1:ns(p)]
-  transnodes = [Node(make_trans(p,t; pos=positions[:T][t])...) for t in 1:nt(p)]
-  stmts = vcat(statenodes, transnodes)
+to_graphviz(pn::Union{
+              AbstractPetriNet,
+              Subobject{<:AbstractPetriNet},
+              StructuredMulticospan{<:StructuredCospans.AbstractDiscreteACSet{<:AbstractPetriNet}},
+            }; kw...) =
+  to_graphviz(to_graphviz_property_graph(pn; kw...))
 
-  i_edges = map(1:ni(p)) do i
-    Edge(make_inpts(p, is(p, i), it(p, i), i)...)
-  end |> collect
-  o_edges = map(1:no(p)) do o
-    Edge(make_otpts(p, os(p, o), ot(p, o), o)...)
-  end |> collect
-  edges = vcat(i_edges, o_edges)
+function to_graphviz_property_graph(pn::AbstractPetriNet;
+    prog::AbstractString="dot", graph_attrs::AbstractDict=Dict(),
+    node_attrs::AbstractDict=Dict(), edge_attrs::AbstractDict=Dict(), name::AbstractString="G", kw...)
+  pg = PropertyGraph{Any}(; name = name, prog = prog,
+    graph = merge!(GRAPH_ATTRS, graph_attrs),
+    node = merge!(NODE_ATTRS, node_attrs),
+    edge = merge!(EDGE_ATTRS, edge_attrs),
+  )
+  S_vtx = Dict(map(parts(pn, :S)) do s
+    s => add_vertex!(pg; label="$(sname(pn, s))", shape="circle", color="#6C9AC3")
+  end)
+  T_vtx = Dict(map(parts(pn, :T)) do t
+    t => add_vertex!(pg; label="$(tname(pn, t))", shape="square", color="#E28F41")
+  end)
 
-  # Add count labels if no labels provided
-  if all(!(:label ∈ keys(e.attrs)) for e in edges)
-    edge_vals = countmap(edges)
-    edges = map(filter((v)->v[2] != 0, collect(edge_vals))) do v
-      attrs = v[1].attrs
-      attrs[:label] = "$(v[2])"
-      Edge(v[1].path, attrs)
-    end |> collect
+  edges = Dict{Tuple{Int,Int}, Int}()
+  map(parts(pn, :I)) do i
+    edge = (S_vtx[pn[i, :is]], T_vtx[pn[i, :it]])
+    edges[edge] = get(edges, edge, 0) + 1
+  end
+  map(parts(pn, :O)) do o
+    edge = (T_vtx[pn[o, :ot]], S_vtx[pn[o, :os]])
+    edges[edge] = get(edges, edge, 0) + 1
+  end
+  for ((src, tgt),count) in edges
+    add_edge!(pg, src, tgt, label="$(count)")
   end
 
-  stmts = vcat(stmts, edges)
-  g = Graphviz.Digraph(name, stmts; prog=prog,
-                                    graph_attrs=graph_attrs,
-                                    node_attrs=node_attrs,
-                                    edge_attrs=edge_attrs)
-  return g
+  pg
 end
 
+function to_graphviz_property_graph(so::Subobject{<:AbstractPetriNet};
+    prog::AbstractString="dot", graph_attrs::AbstractDict=Dict(),
+    node_attrs::AbstractDict=Dict(), edge_attrs::AbstractDict=Dict(),
+    name::AbstractString="G", lw::Number=3.0, kw...)
+  pn = ob(so)
+  comps = hom(so).components
+  sts = comps[:S].func
+  trans = comps[:T].func
+  inps = comps[:I].func
+  otps = comps[:O].func
 
-####################
-# Subgraph Drawing #
-####################
-add_label(n::Node, pre, post) = Node("$pre$(n.name)$post", n.attrs)
-add_label(e::Edge, pre, post) = begin
-  path = map(e.path) do n_id
-    NodeID("$pre$(n_id.name)$post", n_id.port, n_id.anchor)
+  pg = PropertyGraph{Any}(; name = name, prog = prog,
+    graph = merge!(GRAPH_ATTRS, graph_attrs),
+    node = merge!(NODE_ATTRS, node_attrs),
+    edge = merge!(EDGE_ATTRS, edge_attrs),
+  )
+  S_vtx = Dict(map(parts(pn, :S)) do s
+    s => add_vertex!(pg;
+      label="$(sname(pn, s))",
+      shape="circle",
+      fillcolor="#6C9AC3",
+      penwidth = s ∈ sts ? "$lw" : "0.0"
+    )
+  end)
+  T_vtx = Dict(map(parts(pn, :T)) do t
+    t => add_vertex!(pg;
+      label="$(tname(pn, t))",
+      shape="square",
+      fillcolor="#E28F41",
+      penwidth = t ∈ trans ? "$lw" : "0.0"
+    )
+  end)
+
+  edges = Dict{Tuple{Int,Int}, Tuple{Int,Number}}()
+  map(parts(pn, :I)) do i
+    edge = (S_vtx[pn[i, :is]], T_vtx[pn[i, :it]])
+    (count, weight) = get(edges, edge, (0,1))
+    edges[edge] = (count + 1, i ∈ inps ? lw : weight)
   end
-  Edge(path, e.attrs)
-end
-add_label(g::Subgraph, pre, post) = begin
-  stmts = map(g.stmts) do st
-    add_label(st, pre, post)
+  map(parts(pn, :O)) do o
+    edge = (T_vtx[pn[o, :ot]], S_vtx[pn[o, :os]])
+    (count, weight) = get(edges, edge, (0,1))
+    edges[edge] = (count + 1, o ∈ otps ? lw : weight)
   end
-  name = "$pre$(g.name)$post"
-  Subgraph(name, stmts, g.graph_attrs, g.node_attrs, g.edge_attrs)
-end
-
-function tagged_subgraph(g::Graph; pre="", post="")
-  stmts = map(g.stmts) do st
-    add_label(st, pre, post)
+  for ((src, tgt),(count,weight)) in edges
+    add_edge!(pg, src, tgt, label="$(count)", penwidth="$(weight)")
   end
-  Subgraph(g.name, stmts, g.graph_attrs, g.node_attrs, g.edge_attrs)
+
+  pg
 end
 
-function Subgraph(p::AbstractPetriNet; pre="", post="", kw...)
-  tagged_subgraph(Graph(p; kw...); pre=pre, post=post)
-end
+to_graphviz_property_graph(op::StructuredMulticospan{<:StructuredCospans.AbstractDiscreteACSet{<:AbstractPetriNet}}; kw...) =
+  to_graphviz_property_graph(apex(op); kw...)
 
-######################
-# Specialized Graphs #
-######################
-function Graph(m::Multispan{<:AbstractPetriNet})
-  apex = Subgraph(m.apex; name="clusterApex", pre="ap_")
+# Petri Nets Multi-spans
+########################
+
+function to_graphviz(m::Multispan{<:AbstractPetriNet};
+    prog::AbstractString="dot", graph_attrs::AbstractDict=Dict(),
+    node_attrs::AbstractDict=Dict(), edge_attrs::AbstractDict=Dict(),
+    name::AbstractString="G", kw...)
+  apex = Subgraph(m.apex; name="clusterApex", pre="ap_", prog=prog, graph_attrs=graph_attrs, node_attrs=node_attrs, edge_attrs=edge_attrs)
 
   leg_graphs = map(enumerate(m.legs)) do (i, l)
-    Subgraph(l.codom; name="clusterLeg$i", pre="leg$(i)_")
-  end
-
-  graph_attrs = Attributes(:rankdir=>"LR")
-  node_attrs  = Attributes(:shape=>"plain", :style=>"filled", :color=>"white")
-  edge_attrs  = Attributes(:splines=>"splines")
-
-  t_edges = map(enumerate(m.legs)) do (i, l)
-    map(1:nt(m.apex)) do t
-      Edge(["\"ap_t$t\"", "\"leg$(i)_t$(l.components[:T](t))\""],
-      Attributes(:constraint=>"false", :style=>"dotted"))
-    end
+    Subgraph(l.codom; name="clusterLeg$i", pre="leg$(i)_", prog=prog, graph_attrs=graph_attrs, node_attrs=node_attrs, edge_attrs=edge_attrs)
   end
 
   s_edges = map(enumerate(m.legs)) do (i, l)
     map(1:ns(m.apex)) do s
-      Edge(["\"ap_s$s\"", "\"leg$(i)_s$(l.components[:S](s))\""],
+      Edge(["\"ap_n$s\"", "\"leg$(i)_n$(l.components[:S](s))\""],
       Attributes(:constraint=>"false", :style=>"dotted"))
     end
   end
-  stmts = vcat([apex], leg_graphs, t_edges..., s_edges...)
-  g = Graphviz.Digraph("G", stmts; graph_attrs=graph_attrs, node_attrs=node_attrs, edge_attrs=edge_attrs)
-end
 
-function Graph(p::StructACSetTransformation{<:Any, <:Any, <:AbstractPetriNet, <:AbstractPetriNet})
-  Graph(Multispan(p.dom, [p]))
-end
-
-function Graph(so::Subobject{<:AbstractPetriNet}; lw = 3.0, kw...)
-  p = ob(so)
-  maps = hom(so)
-  sts = maps.components[:S].func
-  trans = maps.components[:T].func
-  inps = maps.components[:I].func
-  otps = maps.components[:O].func
-  sns = sname(p, sts)
-  tns = tname(p, trans)
-  mkstate(p,s; kw...) = begin
-    ds = def_states(p,s; kw...)
-    attrs = ds[2]
-    attrs[:fillcolor] = "#6C9AC3"
-    attrs[:color] = "black"
-    attrs[:penwidth] = s ∈ sts ? "$lw" : "0.0"
-    (ds[1], attrs)
-  end
-  mktrans(p,t; kw...) = begin
-    dt = def_trans(p,t; kw...)
-    attrs = dt[2]
-    attrs[:fillcolor] = "#E28F41"
-    attrs[:color] = "black"
-    attrs[:penwidth] = t ∈ trans ? "$lw" : "0.0"
-    (dt[1], attrs)
+  t_edges = map(enumerate(m.legs)) do (i, l)
+    map(1:nt(m.apex)) do t
+      Edge(["\"ap_n$(t+ns(m.apex))\"", "\"leg$(i)_n$(l.components[:T](t)+ns(l.codom))\""],
+      Attributes(:constraint=>"false", :style=>"dotted"))
+    end
   end
 
-  mkinpts(p, s, t, i) = begin
-    (["s$s", "t$t"],
-     Attributes(:labelfontsize=>"6",
-                :penwidth=>(i ∈ inps ? "$lw" : "1.0")))
-  end
-
-  mkotpts(p, s, t, o) = begin
-    (["t$t", "s$s"],
-     Attributes(:labelfontsize=>"6",
-                :penwidth=>(o ∈ otps ? "$lw" : "1.0")))
-  end
-
-  Graph(p; make_states=mkstate, make_trans=mktrans, make_inpts=mkinpts, make_otpts=mkotpts,
-        node_attrs  = Attributes(:shape=>"plain", :style=>"filled, solid", :color=>"white"),
-        kw...)
+  g = Digraph(name, vcat([apex], leg_graphs, t_edges..., s_edges...); prog=prog,
+    graph_attrs = merge!(GRAPH_ATTRS, graph_attrs),
+    node_attrs = merge!(NODE_ATTRS, node_attrs),
+    edge_attrs = merge!(EDGE_ATTRS, edge_attrs)
+  )
 end
 
-function Graph(op::Union{OpenPetriNet, OpenLabelledPetriNetUntyped, OpenReactionNet, OpenLabelledReactionNetUntyped})
-    Graph(apex(op))
-end
+to_graphviz(p::StructACSetTransformation{<:Any, <:Any, <:AbstractPetriNet, <:AbstractPetriNet}; kw...) =
+  to_graphviz(Multispan(p.dom, [p]); kw...)
+
+# Subgraph Extensions
+#####################
+
+add_label(n::Node, pre, post) = Node("$pre$(n.name)$post", n.attrs)
+add_label(e::Edge, pre, post) = Edge(map(e.path) do n_id
+                                  NodeID("$pre$(n_id.name)$post", n_id.port, n_id.anchor)
+                                end, e.attrs)
+add_label(g::Subgraph, pre, post) = Subgraph("$pre$(g.name)$post",
+                                             map(g.stmts) do st
+                                               add_label(st, pre, post)
+                                             end,
+                                             g.graph_attrs, g.node_attrs, g.edge_attrs)
+
+tagged_subgraph(g::Graph; pre="", post="") = Subgraph(g.name,
+                                                      map(g.stmts) do st
+                                                        add_label(st, pre, post)
+                                                      end,
+                                                      g.graph_attrs, g.node_attrs, g.edge_attrs)
+
+Subgraph(p::AbstractPetriNet; pre="", post="", kw...) = tagged_subgraph(to_graphviz(p; kw...); pre=pre, post=post)

--- a/test/BilayerNetworks.jl
+++ b/test/BilayerNetworks.jl
@@ -31,7 +31,6 @@ display_uwd(sir)
 
 psir = apex(oapply_epi(sir))
 psir
-Graph(psir)
 
 # Convert the Petri network into a bilayer network and draw it.
 # This model uses a computation graph to express the computation of the vector field of the Petri net.
@@ -41,8 +40,8 @@ lab_bnsir = LabelledBilayerNetwork()
 migrate!(bnsir, psir)
 migrate!(lab_bnsir, psir)
 bnsir
-@test typeof(to_graphviz(bnsir)) == Graph
-@test typeof(to_graphviz(lab_bnsir)) == Graph
+@test to_graphviz(bnsir) isa Graphics.Graphviz.Graph
+@test to_graphviz(lab_bnsir) isa Graphics.Graphviz.Graph
 
 bnsir_test = @acset BilayerNetwork begin
     Qin = 3

--- a/test/ModelComparison.jl
+++ b/test/ModelComparison.jl
@@ -2,7 +2,7 @@ module TestModelComparison
 
 using Test
 using AlgebraicPetri, AlgebraicPetri.ModelComparison
-using Catlab.CategoricalAlgebra
+using Catlab.CategoricalAlgebra, Catlab.Graphics
 
 SIRD = LabelledReactionNet{Float64, Float64}([:S=>0.0, :I=>0.0, :R=>0.0, :D=>0.0],
                                              (:inf=>0.0)=>((:S,:I)=>(:I,:I)),
@@ -26,12 +26,12 @@ for pn in [models,
   @test apex(c_res) == pn[1]
   @test length(legs(c_res)) == 2
 
-  @test Graph(legs(c_res)[1]) isa Graph
-  @test Graph(c_res) isa Graph
+  @test to_graphviz(legs(c_res)[1]) isa Graphics.Graphviz.Graph
+  @test to_graphviz(c_res) isa Graphics.Graphviz.Graph
 
   so = Subobject.(legs(c_res))
   for s in so
-    @test Graph(s) isa Graph
+    @test to_graphviz(s) isa Graphics.Graphviz.Graph
     @test codom(hom(s)) == pn[2]
   end
 

--- a/test/algebraicpetri/petri.jl
+++ b/test/algebraicpetri/petri.jl
@@ -3,7 +3,7 @@ module TestPetri
 using Test
 using AlgebraicPetri
 using Catlab.CategoricalAlgebra
-using Catlab.Graphs, Catlab.Graphics.Graphviz
+using Catlab.Graphs, Catlab.Graphics
 
 f = Open([1, 2], PetriNet(4, (1,3), (2,4)), [3, 4])
 
@@ -44,20 +44,20 @@ lrn′ = Open([:I], LabelledReactionNet{Number,Int}([:I=>10, :R=>0], ((:rec=>.25
 @test lrn == lrn′
 
 death_petri = Open(PetriNet(1, 1=>()));
-@test AlgebraicPetri.Graph(death_petri) isa Graphviz.Graph
+@test to_graphviz(death_petri) isa Graphics.Graphviz.Graph
 
 # Test visualization of nested subgraphs
 SIR  = LabelledReactionNet{Float64, Float64}([:S=>1.0, :I=>0.0, :R=>0.0],
                                              (:inf=>0.5)=>((:S,:I)=>(:I,:I)),
                                              (:rec=>0.1)=>(:I=>:R))
-stmts1 = Vector{Statement}([AlgebraicPetri.Subgraph(SIR; pre="1_")])
-graph_attrs = Attributes(:rankdir=>"LR")
-node_attrs  = Attributes(:shape=>"plain", :style=>"filled", :color=>"white")
-edge_attrs  = Attributes(:splines=>"splines")
-g = Graphviz.Digraph("G", stmts1; graph_attrs=graph_attrs, node_attrs=node_attrs, edge_attrs=edge_attrs)
-stmts2 = Vector{Statement}([AlgebraicPetri.tagged_subgraph(g; post="_2")])
-g2 = Graphviz.Digraph("G", stmts2; graph_attrs=graph_attrs, node_attrs=node_attrs, edge_attrs=edge_attrs)
-@test g2 isa Graphviz.Graph
-@test g2.stmts[1].stmts[1].stmts[1].name == "1_s1_2"
+stmts1 = Vector{Graphics.Graphviz.Statement}([AlgebraicPetri.Subgraph(SIR; pre="1_")])
+graph_attrs = Graphics.Graphviz.Attributes(:rankdir=>"LR")
+node_attrs  = Graphics.Graphviz.Attributes(:shape=>"plain", :style=>"filled", :color=>"white")
+edge_attrs  = Graphics.Graphviz.Attributes(:splines=>"splines")
+g = Graphics.Graphviz.Digraph("G", stmts1; graph_attrs=graph_attrs, node_attrs=node_attrs, edge_attrs=edge_attrs)
+stmts2 = Vector{Graphics.Graphviz.Statement}([AlgebraicPetri.tagged_subgraph(g; post="_2")])
+g2 = Graphics.Graphviz.Digraph("G", stmts2; graph_attrs=graph_attrs, node_attrs=node_attrs, edge_attrs=edge_attrs)
+@test g2 isa Graphics.Graphviz.Graph
+@test g2.stmts[1].stmts[1].stmts[1].name == "1_n1_2"
 
 end

--- a/test/algebraicpetri/types.jl
+++ b/test/algebraicpetri/types.jl
@@ -2,7 +2,7 @@ module TestTypes
 
 using Test
 using AlgebraicPetri
-using Catlab.CategoricalAlgebra
+using Catlab.CategoricalAlgebra, Catlab.Graphics
 using LabelledArrays
 using Tables
 
@@ -58,12 +58,12 @@ open_sir_lrxn = Open([:S, :I], sir_lrxn, [:R])
 
 @test sir_tpetri == sir_petri
 
-@test typeof(Graph(sir_petri)) == Graph
-@test typeof(Graph(sir_lpetri)) == Graph
-@test typeof(Graph(sir_rxn)) == Graph
-@test typeof(Graph(open_sir_rxn)) == Graph
-@test typeof(Graph(sir_lrxn)) == Graph
-@test typeof(Graph(open_sir_lrxn)) == Graph
+@test to_graphviz(sir_petri) isa Graphics.Graphviz.Graph
+@test to_graphviz(sir_lpetri) isa Graphics.Graphviz.Graph
+@test to_graphviz(sir_rxn) isa Graphics.Graphviz.Graph
+@test to_graphviz(open_sir_rxn) isa Graphics.Graphviz.Graph
+@test to_graphviz(sir_lrxn) isa Graphics.Graphviz.Graph
+@test to_graphviz(open_sir_lrxn) isa Graphics.Graphviz.Graph
 
 @test inputs(sir_petri, 1) == [1, 2]
 @test outputs(sir_petri, 1) == [2, 2]

--- a/test/ext/AlgebraicPetriModelingToolkitExt.jl
+++ b/test/ext/AlgebraicPetriModelingToolkitExt.jl
@@ -44,6 +44,6 @@ petri_example = ODESystem(eqs, t, name=:PetriNet)
 @test ODESystem(psir) == petri_example
 @test ODESystem(bnsir) == bilayer_example
 @test ODESystem(bnsir, simplify = true) == simp_bilayer_example
-@test typeof(ODESystem(PetriNet(psir))) == ODESystem # Sanity check that non-labelled Petri Nets resolve correctly
+@test ODESystem(PetriNet(psir)) isa ODESystem # Sanity check that non-labelled Petri Nets resolve correctly
 
 end


### PR DESCRIPTION
### TODO

- [x] Graphing of basic petri nets of all types
- [x] Graphing of algebraicpetri subobjects
- [x] Graphing of multicospans
- [x] Update tests
- [x] Update examples in documentation to use `to_graphviz` instead of `Graph`

Resolves #100