### PR TITLE
changed indexing in vectorfield

### DIFF
--- a/src/AlgebraicPetri.jl
+++ b/src/AlgebraicPetri.jl
@@ -293,13 +293,13 @@ vectorfield(pn::AbstractPetriNet) = begin
   dt = tm.output - tm.input
   (du, u, p, t) -> begin
     rates = zeros(valtype(du), nt(pn))
-    u_m = [u[sname(pn, i)] for i in 1:ns(pn)]
-    p_m = [p[tname(pn, i)] for i in 1:nt(pn)]
+    u_m = [u[i] for i in 1:ns(pn)]
+    p_m = [p[i] for i in 1:nt(pn)]
     for i in 1:nt(pn)
       rates[i] = valueat(p_m[i], u, t) * prod(u_m[j]^tm.input[i, j] for j in 1:ns(pn))
     end
     for j in 1:ns(pn)
-      du[sname(pn, j)] = sum(rates[i] * dt[i, j] for i in 1:nt(pn); init=0.0)
+      du[j] = sum(rates[i] * dt[i, j] for i in 1:nt(pn); init=0.0)
     end
     du
   end


### PR DESCRIPTION
Changed the indexing into the state vector in order to make it work for labelled Petri/reaction nets as well as normal Petri nets.