### PR TITLE
Fix bad assumption in `oapply_typed`

### DIFF
--- a/docs/literate/covid/stratification.jl
+++ b/docs/literate/covid/stratification.jl
@@ -25,7 +25,7 @@ to_graphviz(infectious_ontology)
 # Here we add reflexive transitions to the susceptible, infected, and recovered populations but we leave out the dead
 # population because they cannote do things such as get vaccinated or travel between regions.
 
-sird_uwd = @relation () where {(S::Pop, I::Pop, R::Pop, D::Pop)} begin
+sird_uwd = @relation (S,I,R,D) where (S::Pop, I::Pop, R::Pop, D::Pop) begin
   infect(S, I, I, I)
   disease(I, R)
   disease(I, D)
@@ -40,7 +40,7 @@ to_graphviz(dom(sird_model))
 
 # ### Masking model
 
-masking_uwd = @relation () where {(M::Pop, UM::Pop)} begin
+masking_uwd = @relation (M,UM) where (M::Pop, UM::Pop) begin
   disease(M, UM)
   disease(UM, M)
   infect(M, UM, M, UM)
@@ -57,7 +57,7 @@ typed_product(sird_model, mask_model) |> dom |> to_graphviz
 
 # ### Vaccine model
 
-vax_uwd = @relation () where {(UV::Pop, V::Pop)} begin
+vax_uwd = @relation (UV,V) where (UV::Pop, V::Pop) begin
   strata(UV, V)
   infect(V, V, V, V)
   infect(V, UV, V, UV)
@@ -75,7 +75,7 @@ typed_product(sird_model, vax_model) |> dom |> to_graphviz
 
 # ### Mask-Vax Model
 
-mask_vax_uwd = @relation () where {(UV_UM::Pop, UV_M::Pop, V_UM::Pop, V_M::Pop)} begin
+mask_vax_uwd = @relation (UV_UM,UV_M,V_UM,V_M) where (UV_UM::Pop, UV_M::Pop, V_UM::Pop, V_M::Pop) begin
   strata(UV_UM, UV_M)
   strata(UV_M, UV_UM)
   strata(V_UM, V_M)
@@ -113,11 +113,13 @@ typed_product(sird_model, mask_vax_model) |> dom |> to_graphviz
 # to infect other people in the same region.
 
 function travel_model(n)
-  uwd = RelationalPrograms.TypedUnnamedRelationDiagram{Symbol,Symbol,Symbol}()
+  uwd = RelationDiagram(repeat([:Pop], n))
   junctions = Dict(begin
-    junction = Symbol("Region$(i)")
-    junction => add_junction!(uwd, :Pop, variable=junction)
-  end for i in 1:n)
+    variable = Symbol("Region$(i)")
+    junction = add_junction!(uwd, :Pop, variable=variable)
+    set_junction!(uwd, port, junction, outer=true)
+    variable => junction
+  end for (i, port) in enumerate(ports(uwd, outer=true)))
 
   pairs = filter(x -> first(x) != last(x), collect(Iterators.product(keys(junctions), keys(junctions))))
   for pair in pairs
@@ -172,7 +174,7 @@ end
 #
 # BIOMD0000000955_miranet
 
-m1_model = (@relation () where {(S::Pop, I::Pop, D::Pop, A::Pop, R::Pop, T::Pop, H::Pop, E::Pop)} begin
+m1_model = (@relation (S,I,D,A,R,T,H,E) where (S::Pop, I::Pop, D::Pop, A::Pop, R::Pop, T::Pop, H::Pop, E::Pop) begin
   infect(S, D, I, D)
   infect(S, A, I, A)
   infect(S, R, I, R)
@@ -197,7 +199,7 @@ to_graphviz(dom(m1_model))
 #
 # BIOMD0000000960_miranet
 
-m2_model = (@relation () where {(S::Pop, E::Pop, I::Pop, A::Pop, H::Pop, R::Pop, D::Pop)} begin
+m2_model = (@relation (S,E,I,A,H,R,D) where (S::Pop, E::Pop, I::Pop, A::Pop, H::Pop, R::Pop, D::Pop) begin
   infect(S, I, E, I)
   infect(S, A, E, A)
   infect(S, H, E, H)
@@ -218,7 +220,7 @@ to_graphviz(dom(m2_model))
 #
 # BIOMD0000000983_miranet
 
-m3_model = (@relation () where {(S::Pop, E::Pop, Iu::Pop, Ir::Pop, Q::Pop, R::Pop, D::Pop)} begin
+m3_model = (@relation (S,E,Iu,Ir,Q,R,D) where (S::Pop, E::Pop, Iu::Pop, Ir::Pop, Q::Pop, R::Pop, D::Pop) begin
   infect(S, Ir, E, Ir)
   infect(S, Iu, E, Iu)
   infect(S, Ir, Q, Ir)

--- a/src/TypedPetri.jl
+++ b/src/TypedPetri.jl
@@ -63,8 +63,13 @@ colimiting the transitions together, and returns the ACSetTransformation
 from that Petri net to the type system.
 """
 function oapply_typed(type_system::LabelledPetriNet, uwd, tnames::Vector{Symbol})
-  junction(uwd, outer=true) == junctions(uwd) ||
-    error("Outer ports of UWD must coincide with junctions in `oapply_typed`")
+  if junction(uwd, outer=true) != junctions(uwd)
+    # XXX: This could be considered a user error, but for the sake of backwards
+    # compatibility, we will fix it for them.
+    uwd = copy(uwd)
+    rem_parts!(uwd, :OuterPort, parts(uwd, :OuterPort))
+    add_parts!(uwd, :OuterPort, njunctions(uwd), outer_junction=junctions(uwd))
+  end
   type_system′ = PetriNet(type_system)
   prim_cospan_data = Dict(
     tname(type_system, t) => prim_cospan(type_system′, t)

--- a/test/TypedPetri.jl
+++ b/test/TypedPetri.jl
@@ -14,7 +14,7 @@ const infectious_ontology = LabelledPetriNet(
   :strata=>(:Pop=>:Pop)
 )
 
-sird_uwd = @relation () where (S::Pop, I::Pop, R::Pop, D::Pop) begin
+sird_uwd = @relation (S,I,R,D) where (S::Pop, I::Pop, R::Pop, D::Pop) begin
   infect(S,I,I,I) # inf
   disease(I,R) # recover
   disease(I,D) # die
@@ -35,7 +35,7 @@ typed_sird = add_params(
 
 # SIRD-with-quarantine model.
 
-quarantine_uwd = @relation () where (Q::Pop, NQ::Pop) begin
+quarantine_uwd = @relation (Q,NQ) where (Q::Pop, NQ::Pop) begin
   strata(Q,NQ) # enter quarantine
   strata(NQ,Q) # exit quarantine
 end

--- a/test/TypedPetri.jl
+++ b/test/TypedPetri.jl
@@ -25,6 +25,15 @@ typed_sird_no_params = oapply_typed(infectious_ontology, sird_uwd,
 @test ns(dom(typed_sird_no_params)) == 4
 @test nt(dom(typed_sird_no_params)) == 3
 
+# Backwards compatibility: allow UWDs with no outer ports.
+sird_uwd_no_outer = @relation () where (S::Pop, I::Pop, R::Pop, D::Pop) begin
+  infect(S,I,I,I) # inf
+  disease(I,R) # recover
+  disease(I,D) # die
+end
+@test oapply_typed(infectious_ontology, sird_uwd_no_outer,
+                   [:inf, :recover, :die]) == typed_sird_no_params
+
 typed_sird = add_params(
   oapply_typed(infectious_ontology, sird_uwd, [:inf, :recover, :die]),
   Dict(:S => 1.0, :I => 1.0, :R => 0.0, :D => 0.0),


### PR DESCRIPTION
Resolves #155. Note that the fix requires exposing the junctions in the UWD through outer ports, hence is also a breaking change. See the changes to the unit tests.