### PR TITLE
Allow Catlab v0.16 in compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ AlgebraicPetriOrdinaryDiffEqExt = "OrdinaryDiffEq"
 
 [compat]
 Catalyst = "13"
-Catlab = "0.15.5"
+Catlab = "0.15.5, 0.16"
 GeneralizedGenerated = "0.3"
 LabelledArrays = "1"
 ModelingToolkit = "8"


### PR DESCRIPTION
No code changes needed and Catlab v0.15.5 still supported!

Closes #161.