### PR TITLE
removed redundant ODEProblem overload

### DIFF
--- a/ext/AlgebraicPetriModelingToolkitExt.jl
+++ b/ext/AlgebraicPetriModelingToolkitExt.jl
@@ -47,11 +47,6 @@ function ModelingToolkit.ODESystem(p::AbstractPetriNet; name=:PetriNet, kws...)
   ODESystem(eqs, t, S, r; name=name, kws...)
 end
 
-function ModelingToolkit.ODEProblem(p::AbstractPetriNet, tspan; name=:PetriNet, kwargs...)
-  sys = ODESystem(p; name)
-  ODEProblem(sys, p[:,:concentration], tspan, p[:,:rate]; kwargs...)
-end
-
 """
   ODESystem(bn::Union{AbstractLabelledBilayerNetwork,AbstractBilayerNetwork}; name=:BilayerNetwork, simplify = false)
 


### PR DESCRIPTION
It seems like the modelingtoolkit extension mostly overloads ODEProblem, which we can overload without depending on modelingtoolkit.

We might want to see what parts of the modelingtoolkit extension can be moved over to just the OrdinaryDiffEq extension.