### PR TITLE
Updates for Catlab 0.17

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "AlgebraicPetri"
 uuid = "4f99eebe-17bf-4e98-b6a1-2c4f205a959b"
 license = "MIT"
 authors = ["Micah Halter <micah@mehalter.com>"]
-version = "0.9.2"
+version = "0.10.1"
 
 [deps]
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
@@ -21,7 +21,7 @@ AlgebraicPetriOrdinaryDiffEqExt = "OrdinaryDiffEq"
 
 [compat]
 Catalyst = "13"
-Catlab = "0.15.5, 0.16"
+Catlab = "0.17"
 GeneralizedGenerated = "0.3"
 LabelledArrays = "1"
 ModelingToolkit = "8, 9"

--- a/src/ModelComparison.jl
+++ b/src/ModelComparison.jl
@@ -18,18 +18,19 @@ This function does restrict to homomorphisms which preserve the transition
 signatures (number of input/output wires).
 """
 function petri_homomorphisms(p1::AbstractPetriNet, p2::AbstractPetriNet; kw...)
+  cat = ACSetCategory(ACSetCat(p1))
   results = ACSetTransformation[]
   sigsTS = Set{Vector{Int}}()
-  homs = homomorphisms(PetriNet(p1), PetriNet(p2); kw...)
+  homs = homomorphisms(PetriNet(p1), PetriNet(p2); cat, kw...)
   for transform in homs
     if all([length(inputs(p1, t)) == length(inputs(p2, transform.components[:T](t))) &&
             length(outputs(p1, t)) == length(outputs(p2, transform.components[:T](t)))
             for t in 1:nt(p1)]) &&
-        vcat(transform.components[:T].func, transform.components[:S].func) ∉ sigsTS
+        vcat(collect(transform.components[:T]), collect(transform.components[:S])) ∉ sigsTS
 
       push!(results, ACSetTransformation(deepcopy(transform.components), p1, p2))
-      push!(sigsTS, vcat(transform.components[:T].func,
-                         transform.components[:S].func))
+      push!(sigsTS, vcat(collect(transform.components[:T]),
+                         collect(transform.components[:S])))
     end
   end
   results

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -56,10 +56,10 @@ function to_graphviz_property_graph(so::Subobject{<:AbstractPetriNet};
     name::AbstractString="G", lw::Number=3.0, kw...)
   pn = ob(so)
   comps = hom(so).components
-  sts = comps[:S].func
-  trans = comps[:T].func
-  inps = comps[:I].func
-  otps = comps[:O].func
+  sts = collect(comps[:S])
+  trans = collect(comps[:T])
+  inps = collect(comps[:I])
+  otps = collect(comps[:O])
 
   pg = PropertyGraph{Any}(; name = name, prog = prog,
     graph = merge!(GRAPH_ATTRS, graph_attrs),

--- a/test/TypedPetri.jl
+++ b/test/TypedPetri.jl
@@ -68,7 +68,10 @@ typed_sird_aug = add_reflexives(
 )
 
 stratified = typed_product(typed_quarantine_aug, typed_sird_aug)
-@test flatten_labels(stratified).dom == flatten_labels(typed_product([typed_quarantine_aug, typed_sird_aug])).dom
+fl_strat = dom(flatten_labels(stratified))
+tp = typed_product([typed_quarantine_aug, typed_sird_aug])
+fl_tp = dom(flatten_labels(tp))
+@test fl_strat == fl_tp
 @test ns(dom(stratified)) == 8
 @test nt(dom(stratified)) == 6 + 4 + 1
 @test dom(stratified)[1,:sname] isa Tuple{Symbol, Symbol}

--- a/test/algebraicpetri/petri.jl
+++ b/test/algebraicpetri/petri.jl
@@ -2,7 +2,7 @@ module TestPetri
 
 using Test
 using AlgebraicPetri
-using Catlab.CategoricalAlgebra, Catlab.Theories
+using Catlab
 using Catlab.Graphs, Catlab.Graphics
 
 f = Open([1, 2], PetriNet(4, (1,3), (2,4)), [3, 4])
@@ -22,8 +22,8 @@ h_id = h ⋅ id(OpenPetriNetOb(FinSet(1)))
 @test dom(h) == dom(f)
 @test codom(h) == codom(g)
 
-@test h == h′
-@test h == h_id
+@test h ≃ h′
+@test h ≃ h_id
 
 # Test open petri net notations either fully open or by specifying legs
 


### PR DESCRIPTION
Addresses various breaking changes in the Catlab 0.17 release. These include:

- No more `LooseACSetTransformation`: instead stratification limits are in a `LooseACSet` category of ACSets.
- Some uses of `==` in the tests replaced with `≃`
- Components of ACSetTransformations no longer assumed to be `FinFunctionVector`: to get a vector out of a `FinFunction` we now call `collect(f)` instead of `f.func`.
- `FinDomFunction` ob/hom mappings use presentation generators, not symbols.

There was one logic error in the previous implementation that was revealed in the update process: when we call `flatten_labels` to take a stratified model (which has, for example, `Name` attributes valued in *pairs* of symbols) and convert it to a regular Petri net (`Name` valued in just symbols with a `_` in the middle of the pair), the code previously did not change the components of typing hom that is going out of the model into a typing petri net. This needed to be fixed because otherwise a type error would be encountered (trying to use a function with domain `Tuple{String,String}`  when a function with domain `String` was needed).